### PR TITLE
feat: Deck category 검색 API 및 성능 벤치마크 도구 추가

### DIFF
--- a/UserService/src/main/java/com/lbs/user/card/controller/DeckController.java
+++ b/UserService/src/main/java/com/lbs/user/card/controller/DeckController.java
@@ -119,6 +119,14 @@ public class DeckController {
                 .body(ApiResponse.success(HttpStatus.OK,"card 등록 완료했습니다." , cardResponseDto));
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Slice<DeckResponseDto>>> searchByCategory(
+            @RequestParam String category, Pageable pageable) {
+        Slice<DeckResponseDto> result = deckService.searchByCategory(category, pageable);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(HttpStatus.OK, "검색 성공", result));
+    }
+
     @PostMapping("/{id}/transaction-rollback-test-with-error")
     public ResponseEntity<ApiResponse<String>> transactionRollbackTestWithError(
             @PathVariable("id") Long id,

--- a/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/DeckRepository.java
+++ b/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/DeckRepository.java
@@ -26,5 +26,7 @@ public interface DeckRepository {
     void setDeckCardCount();
     void updateCardCount();
 
+    Slice<DeckResponseDto> findByCategory(String category, Pageable pageable);
+
 }
 

--- a/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/jpa/JpaDeckRepository.java
+++ b/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/jpa/JpaDeckRepository.java
@@ -42,4 +42,6 @@ public interface JpaDeckRepository extends JpaRepository<DeckEntity, Long> {
 //    @EntityGraph(attributePaths = {"cards"})
 //    Page<DeckEntity> findAllBy(Pageable pageable);
 
+    Slice<DeckEntity> findAllByCategory(String category, Pageable pageable);
+
 }

--- a/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/jpa/JpaDeckRepositoryAdapter.java
+++ b/UserService/src/main/java/com/lbs/user/card/infrastructure/repository/jpa/JpaDeckRepositoryAdapter.java
@@ -159,6 +159,13 @@ public class JpaDeckRepositoryAdapter implements DeckRepository {
         return cardId;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Slice<DeckResponseDto> findByCategory(String category, Pageable pageable) {
+        Slice<DeckEntity> slice = jpaDeckRepository.findAllByCategory(category, pageable);
+        return slice.map(deckMapper::entityToResponseDto);
+    }
+
    @Override
     public void setDeckCardCount(){
 

--- a/UserService/src/main/java/com/lbs/user/card/seed/DeckSeedRunner.java
+++ b/UserService/src/main/java/com/lbs/user/card/seed/DeckSeedRunner.java
@@ -1,0 +1,46 @@
+package com.lbs.user.card.seed;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Profile("seed")
+@RequiredArgsConstructor
+@Slf4j
+public class DeckSeedRunner implements CommandLineRunner {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(String... args) {
+        String[] categories = {"수학", "영어", "과학", "국어", "사회"};
+        int batchSize = 1000;
+        int perCategory = 20_000;
+
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        String sql = "INSERT INTO decks (title, description, category, tag, card_count, created_by, last_modified_by, created_date, last_modified_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        for (String cat : categories) {
+            List<Object[]> batch = new ArrayList<>();
+            for (int i = 0; i < perCategory; i++) {
+                String title = "BENCH_" + UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+                batch.add(new Object[]{title, "벤치마크 테스트 데이터 " + i, cat, "bench", 0, "seed", "seed", now, now});
+                if (batch.size() == batchSize) {
+                    jdbcTemplate.batchUpdate(sql, batch);
+                    batch.clear();
+                }
+            }
+            if (!batch.isEmpty()) jdbcTemplate.batchUpdate(sql, batch);
+            log.info("시드 완료: {} - {}건", cat, perCategory);
+        }
+        log.info("전체 시드 완료: 100,000건");
+    }
+}

--- a/UserService/src/main/java/com/lbs/user/card/service/DeckService.java
+++ b/UserService/src/main/java/com/lbs/user/card/service/DeckService.java
@@ -3,7 +3,10 @@ package com.lbs.user.card.service;
 import com.lbs.user.card.domain.Card;
 import com.lbs.user.card.domain.Deck;
 import com.lbs.user.card.dto.request.CreateCardRequestDto;
+import com.lbs.user.card.dto.response.DeckResponseDto;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -17,6 +20,8 @@ public interface DeckService {
     Card createCard(Card card);
     Long deleteCard(Long id, Long cardId);
 //    List<Deck> readPageDecks(PageRequest pageRequest);
-public Deck updateCardCountWithTransactionTest(Long id, int newCardCount, boolean causeError);
+    Deck updateCardCountWithTransactionTest(Long id, int newCardCount, boolean causeError);
+
+    Slice<DeckResponseDto> searchByCategory(String category, Pageable pageable);
 
 }

--- a/UserService/src/main/java/com/lbs/user/card/service/DeckServiceImpl.java
+++ b/UserService/src/main/java/com/lbs/user/card/service/DeckServiceImpl.java
@@ -2,12 +2,16 @@ package com.lbs.user.card.service;
 
 import com.lbs.user.card.domain.Card;
 import com.lbs.user.card.domain.Deck;
+import com.lbs.user.card.dto.response.DeckResponseDto;
 import com.lbs.user.card.infrastructure.repository.DeckRepository;
 import com.lbs.user.common.exception.DeckNotFoundException;
 import com.lbs.user.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -71,5 +75,11 @@ public class DeckServiceImpl implements DeckService {
 
         deckRepository.updateCardCount();
         return null;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Slice<DeckResponseDto> searchByCategory(String category, Pageable pageable) {
+        return deckRepository.findByCategory(category, pageable);
     }
 }

--- a/scripts/k6/deck-search.js
+++ b/scripts/k6/deck-search.js
@@ -1,0 +1,39 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    ramping: {
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '1m', target: 50 },
+        { duration: '2m', target: 100 },
+        { duration: '2m', target: 200 },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+const CATEGORIES = ['수학', '영어', '과학', '국어', '사회'];
+const BASE = __ENV.BASE_URL || 'http://evil55.cloud/api/user-service';
+
+export default function () {
+  const cat = CATEGORIES[Math.floor(Math.random() * CATEGORIES.length)];
+  const page = Math.floor(Math.random() * 50);
+  const res = http.get(
+    `${BASE}/deck/search?category=${encodeURIComponent(cat)}&sort=createdDate,desc&page=${page}&size=20`
+  );
+  check(res, { 'status 200': (r) => r.status === 200 });
+}
+
+export function handleSummary(data) {
+  return {
+    'docs/perf/results/summary.json': JSON.stringify(data, null, 2),
+    stdout: JSON.stringify(data.metrics['http_req_duration'], null, 2),
+  };
+}

--- a/scripts/k6/run-benchmark.sh
+++ b/scripts/k6/run-benchmark.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# 3단계 벤치마크 실행 스크립트
+# k6는 로컬 PC에서 실행 (실제 사용자 관점, 인터넷 RTT 포함)
+# 사전 요구사항: k6 설치 (https://k6.io/docs/getting-started/installation/)
+
+set -e
+
+BASE_URL="${BASE_URL:-http://evil55.cloud/api/user-service}"
+SCRIPT="$(dirname "$0")/deck-search.js"
+RESULTS_DIR="docs/perf/results"
+mkdir -p "$RESULTS_DIR"
+
+echo "======================================"
+echo " Deck 조회 성능 벤치마크"
+echo " 대상: $BASE_URL"
+echo " 주의: 인터넷 RTT 포함 측정값"
+echo "======================================"
+
+# Stage 1: Baseline (인덱스 없음)
+echo ""
+echo "[1/3] Baseline 측정 시작 (인덱스 없음, PK만 존재)"
+echo "  → 현재 상태 그대로 측정합니다."
+read -p "  준비되면 Enter..."
+k6 run -e BASE_URL="$BASE_URL" \
+  --out json="$RESULTS_DIR/baseline.json" \
+  "$SCRIPT"
+cp "$RESULTS_DIR/summary.json" "$RESULTS_DIR/baseline-summary.json"
+echo "  ✓ Baseline 측정 완료 → $RESULTS_DIR/baseline-summary.json"
+
+# Stage 2: Index 적용
+echo ""
+echo "[2/3] Index 적용 후 측정"
+echo "  → 다음 SQL을 lbs-server MySQL에 실행하세요:"
+echo "     ALTER TABLE decks ADD INDEX idx_category_created_date (category, created_date DESC);"
+read -p "  인덱스 추가 완료 후 Enter..."
+k6 run -e BASE_URL="$BASE_URL" \
+  --out json="$RESULTS_DIR/index.json" \
+  "$SCRIPT"
+cp "$RESULTS_DIR/summary.json" "$RESULTS_DIR/index-summary.json"
+echo "  ✓ Index 측정 완료 → $RESULTS_DIR/index-summary.json"
+
+# Stage 3: Cache 적용
+echo ""
+echo "[3/3] Cache 적용 후 측정"
+echo "  → UserService에 CacheConfig + @Cacheable 추가 후 배포하세요."
+echo "  → redis-cli FLUSHDB 실행 후 진행하세요."
+read -p "  캐시 적용 및 배포 완료 후 Enter..."
+k6 run -e BASE_URL="$BASE_URL" \
+  --out json="$RESULTS_DIR/cache.json" \
+  "$SCRIPT"
+cp "$RESULTS_DIR/summary.json" "$RESULTS_DIR/cache-summary.json"
+echo "  ✓ Cache 측정 완료 → $RESULTS_DIR/cache-summary.json"
+
+echo ""
+echo "======================================"
+echo " 전체 측정 완료"
+echo " 결과 파일: $RESULTS_DIR/"
+echo "======================================"


### PR DESCRIPTION
## Summary
- `GET /deck/search?category={x}&sort=createdDate,desc&page=N&size=20` 엔드포인트 신규 추가
- `DeckSeedRunner`: `@Profile("seed")` 활성화 시 5개 카테고리 × 20,000건 = 100,000건 JDBC batch insert (title prefix `BENCH_`로 cleanup 가능)
- `scripts/k6/deck-search.js`: Ramping VUs (0→50→100→200→0) 부하 시나리오, p95<500ms 임계값
- `scripts/k6/run-benchmark.sh`: Baseline → Index → Cache 3단계 자동 측정 스크립트

## 측정 시나리오
인덱스 없음 → `(category, created_date DESC)` 복합 인덱스 → Spring Cache + Redis 순서로 성능 비교 예정

## Test plan
- [ ] `GET /deck/search?category=수학&sort=createdDate,desc&page=0&size=20` 200 응답 확인
- [ ] 시드 데이터 삽입: `SPRING_PROFILES_ACTIVE=prod,seed` 로 UserService 일회 기동
- [ ] k6 smoke test: `k6 run --vus 1 --duration 10s scripts/k6/deck-search.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)