### PR TITLE
perf: Deck category + created_date 복합 인덱스 추가

### DIFF
--- a/UserService/src/main/java/com/lbs/user/card/infrastructure/entity/DeckEntity.java
+++ b/UserService/src/main/java/com/lbs/user/card/infrastructure/entity/DeckEntity.java
@@ -22,7 +22,9 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
-@Table(name = "decks")
+@Table(name = "decks", indexes = {
+    @Index(name = "idx_category_created_date", columnList = "category, created_date DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeckEntity extends BaseEntity {
 


### PR DESCRIPTION
## Summary
- `DeckEntity`에 `idx_category_created_date (category, created_date DESC)` 복합 인덱스 추가
- `GET /deck/search?category={x}&sort=createdDate,desc` 조회 시 풀스캔 → 인덱스 스캔으로 개선
- Baseline 측정 결과: p95 **1402ms** → 인덱스 적용 후 개선 예정

## 벤치마크 시나리오 (3단계)
- [x] Baseline — 인덱스 없음 (p95: 1402ms)
- [x] **Index 적용** ← 이 PR
- [ ] Cache 적용 (Spring Cache + Redis)

## Test plan
- [ ] k6 동일 시나리오 재실행 후 p95 응답시간 비교
- [ ] `EXPLAIN SELECT * FROM decks WHERE category=? ORDER BY created_date DESC` → type=ref 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)