### PR TITLE
feat: add interview mode, custom speaking records, and analysis limit

### DIFF
--- a/SpeakingService/src/main/java/com/lbs/speaking/common/response/ErrorCode.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/common/response/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     AUDIO_DURATION_EXCEEDED(HttpStatus.BAD_REQUEST, "Audio duration exceeds the allowed limit."),
     AUDIO_OBJECT_NOT_FOUND(HttpStatus.BAD_REQUEST, "Uploaded audio object was not found."),
     DUPLICATE_DAILY_ANSWER(HttpStatus.CONFLICT, "Daily question was already answered."),
-    REANALYZE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "Daily reanalysis limit exceeded."),
+    ANALYSIS_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "Daily analysis limit exceeded."),
     LLM_RESPONSE_PARSE_FAILED(HttpStatus.BAD_GATEWAY, "LLM response could not be parsed."),
     LLM_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "LLM request failed."),
     STORAGE_OPERATION_FAILED(HttpStatus.BAD_GATEWAY, "Object storage operation failed."),

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/controller/SpeakingController.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/controller/SpeakingController.java
@@ -30,6 +30,11 @@ public class SpeakingController {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, speakingRecordService.getTodayQuestion()));
     }
 
+    @GetMapping("/interview/today")
+    public ResponseEntity<ApiResponse<SpeakingDtos.TodayQuestionResponse>> getInterviewQuestion() {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, speakingRecordService.getInterviewQuestion()));
+    }
+
     @PostMapping("/uploads/presigned-url")
     public ResponseEntity<ApiResponse<SpeakingDtos.PresignedUploadResponse>> createUploadUrl(
             @RequestHeader(value = "Authorization", required = false) String authorization,
@@ -37,6 +42,15 @@ public class SpeakingController {
     ) {
         Long userId = jwtTokenProvider.resolveUserId(authorization);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, speakingRecordService.createUploadUrl(userId, request)));
+    }
+
+    @PostMapping("/custom/uploads/presigned-url")
+    public ResponseEntity<ApiResponse<SpeakingDtos.PresignedUploadResponse>> createCustomUploadUrl(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody SpeakingDtos.PresignedUploadRequest request
+    ) {
+        Long userId = jwtTokenProvider.resolveUserId(authorization);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, speakingRecordService.createCustomUploadUrl(userId, request)));
     }
 
     @PostMapping("/records")
@@ -47,6 +61,16 @@ public class SpeakingController {
         Long userId = jwtTokenProvider.resolveUserId(authorization);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED, "Record created.", speakingRecordService.createRecord(userId, request)));
+    }
+
+    @PostMapping("/custom/records")
+    public ResponseEntity<ApiResponse<SpeakingDtos.RecordResponse>> createCustomRecord(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody SpeakingDtos.CreateCustomRecordRequest request
+    ) {
+        Long userId = jwtTokenProvider.resolveUserId(authorization);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED, "Record created.", speakingRecordService.createCustomRecord(userId, request)));
     }
 
     @GetMapping("/records/{recordId}/progress")

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/dto/SpeakingDtos.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/dto/SpeakingDtos.java
@@ -1,6 +1,8 @@
 package com.lbs.speaking.speaking.dto;
 
 import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordStatus;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordType;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -17,15 +19,23 @@ public final class SpeakingDtos {
             Long dailyQuestionId,
             LocalDate questionDate,
             Long questionId,
-            String content
+            String content,
+            SpeakingQuestionType questionType
     ) {
+        public TodayQuestionResponse(Long dailyQuestionId, LocalDate questionDate, Long questionId, String content) {
+            this(dailyQuestionId, questionDate, questionId, content, SpeakingQuestionType.DAILY);
+        }
     }
 
     public record PresignedUploadRequest(
             @NotBlank String mimeType,
             @Positive long sizeBytes,
-            @Positive int durationSec
+            @Positive int durationSec,
+            SpeakingQuestionType questionType
     ) {
+        public PresignedUploadRequest(String mimeType, long sizeBytes, int durationSec) {
+            this(mimeType, sizeBytes, durationSec, SpeakingQuestionType.DAILY);
+        }
     }
 
     public record PresignedUploadResponse(
@@ -43,6 +53,14 @@ public final class SpeakingDtos {
     ) {
     }
 
+    public record CreateCustomRecordRequest(
+            @NotBlank String uploadId,
+            @NotBlank String objectKey,
+            @NotBlank String promptText,
+            @NotBlank String transcript
+    ) {
+    }
+
     public record ProgressResponse(
             Long recordId,
             SpeakingRecordStatus status,
@@ -55,6 +73,7 @@ public final class SpeakingDtos {
             Long id,
             Long dailyQuestionId,
             String question,
+            SpeakingRecordType recordType,
             String originalText,
             SpeakingRecordStatus status,
             String failureReason,
@@ -66,6 +85,7 @@ public final class SpeakingDtos {
     public record RecordListItemResponse(
             Long id,
             String question,
+            SpeakingRecordType recordType,
             SpeakingRecordStatus status,
             LocalDateTime createdAt
     ) {
@@ -74,7 +94,8 @@ public final class SpeakingDtos {
     public record AnalysisResponse(
             String improvedText,
             String issuesJson,
-            String renderBlocksJson
+            String renderBlocksJson,
+            String feedbackJson
     ) {
     }
 

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/AnalysisEntity.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/AnalysisEntity.java
@@ -41,21 +41,36 @@ public class AnalysisEntity extends BaseEntity {
     @Column(name = "render_blocks_json", nullable = false, columnDefinition = "JSON")
     private String renderBlocksJson;
 
-    private AnalysisEntity(SpeakingRecordEntity record, String improvedText, String issuesJson, String renderBlocksJson) {
+    @Column(name = "feedback_json", columnDefinition = "JSON")
+    private String feedbackJson;
+
+    private AnalysisEntity(SpeakingRecordEntity record, String improvedText, String issuesJson, String renderBlocksJson,
+                           String feedbackJson) {
         this.record = record;
         this.improvedText = improvedText;
         this.issuesJson = issuesJson;
         this.renderBlocksJson = renderBlocksJson;
+        this.feedbackJson = feedbackJson;
     }
 
     public static AnalysisEntity create(SpeakingRecordEntity record, String improvedText, String issuesJson,
                                         String renderBlocksJson) {
-        return new AnalysisEntity(record, improvedText, issuesJson, renderBlocksJson);
+        return new AnalysisEntity(record, improvedText, issuesJson, renderBlocksJson, "{}");
+    }
+
+    public static AnalysisEntity create(SpeakingRecordEntity record, String improvedText, String issuesJson,
+                                        String renderBlocksJson, String feedbackJson) {
+        return new AnalysisEntity(record, improvedText, issuesJson, renderBlocksJson, feedbackJson);
     }
 
     public void replace(String improvedText, String issuesJson, String renderBlocksJson) {
+        replace(improvedText, issuesJson, renderBlocksJson, "{}");
+    }
+
+    public void replace(String improvedText, String issuesJson, String renderBlocksJson, String feedbackJson) {
         this.improvedText = improvedText;
         this.issuesJson = issuesJson;
         this.renderBlocksJson = renderBlocksJson;
+        this.feedbackJson = feedbackJson;
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/DailyQuestionEntity.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/DailyQuestionEntity.java
@@ -3,6 +3,8 @@ package com.lbs.speaking.speaking.infrastructure.entity;
 import com.lbs.speaking.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,8 +23,14 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(
         name = "speaking_daily_questions",
-        uniqueConstraints = @UniqueConstraint(name = "uk_speaking_daily_question_date", columnNames = "question_date"),
-        indexes = @Index(name = "idx_speaking_daily_question_date", columnList = "question_date")
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_speaking_daily_question_date_type",
+                columnNames = {"question_date", "question_type"}
+        ),
+        indexes = {
+                @Index(name = "idx_speaking_daily_question_date", columnList = "question_date"),
+                @Index(name = "idx_speaking_daily_question_date_type", columnList = "question_date, question_type")
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailyQuestionEntity extends BaseEntity {
@@ -34,16 +42,25 @@ public class DailyQuestionEntity extends BaseEntity {
     @Column(name = "question_date", nullable = false)
     private LocalDate questionDate;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type", nullable = false, length = 30)
+    private SpeakingQuestionType questionType;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "question_id", nullable = false)
     private QuestionEntity question;
 
-    private DailyQuestionEntity(LocalDate questionDate, QuestionEntity question) {
+    private DailyQuestionEntity(LocalDate questionDate, SpeakingQuestionType questionType, QuestionEntity question) {
         this.questionDate = questionDate;
+        this.questionType = questionType;
         this.question = question;
     }
 
     public static DailyQuestionEntity create(LocalDate questionDate, QuestionEntity question) {
-        return new DailyQuestionEntity(questionDate, question);
+        return create(questionDate, SpeakingQuestionType.DAILY, question);
+    }
+
+    public static DailyQuestionEntity create(LocalDate questionDate, SpeakingQuestionType questionType, QuestionEntity question) {
+        return new DailyQuestionEntity(questionDate, questionType, question);
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingQuestionType.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingQuestionType.java
@@ -1,0 +1,6 @@
+package com.lbs.speaking.speaking.infrastructure.entity;
+
+public enum SpeakingQuestionType {
+    DAILY,
+    INTERVIEW
+}

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordEntity.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordEntity.java
@@ -42,9 +42,16 @@ public class SpeakingRecordEntity extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "daily_question_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_question_id")
     private DailyQuestionEntity dailyQuestion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "record_type", nullable = false, length = 30)
+    private SpeakingRecordType recordType;
+
+    @Column(name = "prompt_text", columnDefinition = "TEXT")
+    private String promptText;
 
     @Column(name = "object_key", nullable = false, length = 500)
     private String objectKey;
@@ -75,6 +82,7 @@ public class SpeakingRecordEntity extends BaseEntity {
                                  String originalText, String mimeType, long sizeBytes, int durationSec) {
         this.userId = userId;
         this.dailyQuestion = dailyQuestion;
+        this.recordType = SpeakingRecordType.QUESTION_ANALYSIS;
         this.objectKey = objectKey;
         this.originalText = originalText;
         this.mimeType = mimeType;
@@ -89,6 +97,16 @@ public class SpeakingRecordEntity extends BaseEntity {
         return new SpeakingRecordEntity(userId, dailyQuestion, objectKey, originalText, mimeType, sizeBytes, durationSec);
     }
 
+    public static SpeakingRecordEntity createRecordedCustomText(Long userId, String promptText, String objectKey,
+                                                                String originalText, String mimeType, long sizeBytes,
+                                                                int durationSec) {
+        SpeakingRecordEntity record = new SpeakingRecordEntity(userId, null, objectKey, originalText, mimeType, sizeBytes, durationSec);
+        record.recordType = SpeakingRecordType.CUSTOM_TEXT;
+        record.promptText = promptText;
+        record.status = SpeakingRecordStatus.RECORDED;
+        return record;
+    }
+
     public void markAnalyzing(String permanentObjectKey) {
         this.objectKey = permanentObjectKey;
         this.status = SpeakingRecordStatus.ANALYZING;
@@ -97,6 +115,12 @@ public class SpeakingRecordEntity extends BaseEntity {
 
     public void markCompleted() {
         this.status = SpeakingRecordStatus.COMPLETED;
+        this.failureReason = null;
+    }
+
+    public void markRecorded(String permanentObjectKey) {
+        this.objectKey = permanentObjectKey;
+        this.status = SpeakingRecordStatus.RECORDED;
         this.failureReason = null;
     }
 
@@ -111,5 +135,9 @@ public class SpeakingRecordEntity extends BaseEntity {
 
     public boolean belongsTo(Long userId) {
         return this.userId.equals(userId);
+    }
+
+    public boolean isQuestionAnalysis() {
+        return recordType == SpeakingRecordType.QUESTION_ANALYSIS && dailyQuestion != null;
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordStatus.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordStatus.java
@@ -4,5 +4,6 @@ public enum SpeakingRecordStatus {
     PENDING_ANALYSIS,
     ANALYZING,
     COMPLETED,
+    RECORDED,
     FAILED
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordType.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordType.java
@@ -1,0 +1,6 @@
+package com.lbs.speaking.speaking.infrastructure.entity;
+
+public enum SpeakingRecordType {
+    QUESTION_ANALYSIS,
+    CUSTOM_TEXT
+}

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/DailyQuestionJpaRepository.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/DailyQuestionJpaRepository.java
@@ -1,16 +1,20 @@
 package com.lbs.speaking.speaking.infrastructure.repository;
 
 import com.lbs.speaking.speaking.infrastructure.entity.DailyQuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DailyQuestionJpaRepository extends JpaRepository<DailyQuestionEntity, Long> {
 
     Optional<DailyQuestionEntity> findByQuestionDate(LocalDate questionDate);
 
-    @Query("select dq.question.id from DailyQuestionEntity dq")
-    List<Long> findUsedQuestionIds();
+    Optional<DailyQuestionEntity> findByQuestionDateAndQuestionType(LocalDate questionDate, SpeakingQuestionType questionType);
+
+    @Query("select dq.question.id from DailyQuestionEntity dq where dq.questionType = :questionType")
+    List<Long> findUsedQuestionIds(@Param("questionType") SpeakingQuestionType questionType);
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/QuestionJpaRepository.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/QuestionJpaRepository.java
@@ -10,4 +10,12 @@ public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Lon
     List<QuestionEntity> findByActiveTrueAndIdNotIn(Collection<Long> excludedIds);
 
     List<QuestionEntity> findByActiveTrue();
+
+    List<QuestionEntity> findByActiveTrueAndCategory_Name(String categoryName);
+
+    List<QuestionEntity> findByActiveTrueAndCategory_NameAndIdNotIn(String categoryName, Collection<Long> excludedIds);
+
+    List<QuestionEntity> findByActiveTrueAndCategory_NameNot(String categoryName);
+
+    List<QuestionEntity> findByActiveTrueAndCategory_NameNotAndIdNotIn(String categoryName, Collection<Long> excludedIds);
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AnalysisLimitService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AnalysisLimitService.java
@@ -10,26 +10,26 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ReanalysisLimitService {
+public class AnalysisLimitService {
 
     private static final int DAILY_LIMIT = 5;
     private static final Duration COUNTER_TTL = Duration.ofDays(2);
 
     private final StringRedisTemplate redisTemplate;
 
-    public int acquire(Long userId, Long recordId, LocalDate today) {
-        String key = key(userId, recordId, today);
+    public int acquire(Long userId, LocalDate today) {
+        String key = key(userId, today);
         Long count = redisTemplate.opsForValue().increment(key);
         if (count != null && count == 1L) {
             redisTemplate.expire(key, COUNTER_TTL);
         }
         if (count != null && count > DAILY_LIMIT) {
-            throw new BusinessException(ErrorCode.REANALYZE_LIMIT_EXCEEDED);
+            throw new BusinessException(ErrorCode.ANALYSIS_LIMIT_EXCEEDED);
         }
         return count == null ? 1 : count.intValue();
     }
 
-    private String key(Long userId, Long recordId, LocalDate today) {
-        return "speaking:reanalyze:%d:%d:%s".formatted(userId, recordId, today);
+    private String key(Long userId, LocalDate today) {
+        return "speaking:analysis:%d:%s".formatted(userId, today);
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AnalysisProcessingService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AnalysisProcessingService.java
@@ -24,9 +24,17 @@ public class AnalysisProcessingService {
 
     @Transactional
     public void process(Long recordId) {
+        process(recordId, false);
+    }
+
+    @Transactional
+    public void process(Long recordId, boolean force) {
         SpeakingRecordEntity record = recordRepository.findByIdAndDeletedAtIsNull(recordId)
                 .orElseThrow();
-        if (record.getStatus() == SpeakingRecordStatus.COMPLETED) {
+        if (!record.isQuestionAnalysis()) {
+            return;
+        }
+        if (!force && record.getStatus() == SpeakingRecordStatus.COMPLETED) {
             return;
         }
 
@@ -39,8 +47,8 @@ public class AnalysisProcessingService {
 
         var correctedIssues = issueIndexCorrector.correct(record.getOriginalText(), result.issues());
         AnalysisEntity analysis = analysisRepository.findByRecordId(recordId)
-                .orElseGet(() -> AnalysisEntity.create(record, result.improvedText(), "[]", "[]"));
-        analysis.replace(result.improvedText(), toJson(correctedIssues), toJson(result.renderBlocks()));
+                .orElseGet(() -> AnalysisEntity.create(record, result.improvedText(), "[]", "[]", "{}"));
+        analysis.replace(result.improvedText(), toJson(correctedIssues), toJson(result.renderBlocks()), toJson(result.feedback()));
         analysisRepository.save(analysis);
         record.markCompleted();
         progressService.setProgress(recordId, 100);

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiAnalysisParser.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiAnalysisParser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lbs.speaking.common.exception.BusinessException;
 import com.lbs.speaking.common.response.ErrorCode;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -42,11 +43,54 @@ public class GeminiAnalysisParser {
                                     block.color(),
                                     block.issueIndex()
                             ))
-                            .toList()
+                            .toList(),
+                    toFeedback(payload.feedback())
             );
         } catch (JsonProcessingException | IllegalArgumentException exception) {
             throw new BusinessException(ErrorCode.LLM_RESPONSE_PARSE_FAILED, exception);
         }
+    }
+
+    private LlmAnalysisPort.Feedback toFeedback(GeminiFeedback feedback) {
+        if (feedback == null) {
+            return defaultFeedback();
+        }
+        List<LlmAnalysisPort.Metric> metrics = new ArrayList<>();
+        if (feedback.metrics() != null) {
+            metrics.addAll(feedback.metrics().stream()
+                    .map(metric -> new LlmAnalysisPort.Metric(
+                            metric.key(),
+                            metric.label(),
+                            clampScore(metric.score()),
+                            metric.comment()
+                    ))
+                    .toList());
+        }
+        if (metrics.isEmpty()) {
+            return defaultFeedback();
+        }
+        return new LlmAnalysisPort.Feedback(
+                clampScore(feedback.overallScore()),
+                StringUtils.hasText(feedback.overallComment()) ? feedback.overallComment() : "답변을 기준으로 피드백을 확인해 보세요.",
+                metrics
+        );
+    }
+
+    private int clampScore(int score) {
+        return Math.max(0, Math.min(100, score));
+    }
+
+    private LlmAnalysisPort.Feedback defaultFeedback() {
+        return new LlmAnalysisPort.Feedback(
+                70,
+                "구체적인 평가 점수가 없어 기본 피드백을 표시합니다.",
+                List.of(
+                        new LlmAnalysisPort.Metric("fluency", "유창성", 70, "답변 흐름을 조금 더 자연스럽게 다듬어 보세요."),
+                        new LlmAnalysisPort.Metric("vocabulary", "어휘", 70, "상황에 맞는 표현을 조금 더 다양하게 사용해 보세요."),
+                        new LlmAnalysisPort.Metric("structure", "답변 구성", 70, "핵심 생각과 이유를 더 분명하게 연결해 보세요."),
+                        new LlmAnalysisPort.Metric("relevance", "질문 적합도", 70, "질문에 직접 답하는 내용을 더 보강해 보세요.")
+                )
+        );
     }
 
     private String extractJsonObject(String rawResponse) {
@@ -74,8 +118,26 @@ public class GeminiAnalysisParser {
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record GeminiPayload(
             String improvedText,
+            GeminiFeedback feedback,
             List<GeminiIssue> issues,
             List<GeminiRenderBlock> renderBlocks
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiFeedback(
+            int overallScore,
+            String overallComment,
+            List<GeminiMetric> metrics
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record GeminiMetric(
+            String key,
+            String label,
+            int score,
+            String comment
     ) {
     }
 

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiPromptBuilder.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiPromptBuilder.java
@@ -5,50 +5,123 @@ import org.springframework.stereotype.Component;
 @Component
 public class GeminiPromptBuilder {
 
-    public String build(String question, String transcript) {
-        return """
-                You are an English speaking coach for Korean learners.
+    static final String VARIABLE_INPUT_MARKER = "=== VARIABLE INPUT ===";
 
-                Analyze the learner's answer against the question.
-                Focus only on clarity, grammar, natural expression, repetition, filler words, and answer structure.
-                Do not analyze pronunciation, intonation, speech speed, emotion, or audio quality.
+    private static final String CACHEABLE_INSTRUCTION_PREFIX = """
+            You are a speaking practice coach for Korean learners.
 
-                Return only valid JSON. Do not wrap it in markdown. Do not add explanations outside JSON.
+            Cache guidance:
+            - This whole instruction block is intentionally stable.
+            - Do not depend on request-specific data until the VARIABLE INPUT section.
+            - The question and learner answer always appear after the stable instruction block.
 
-                JSON schema:
+            Product goal:
+            - Help the learner practice speaking by reading feedback, studying a model answer, and recording again.
+            - The user interface is Korean, so all explanations must be useful to a Korean learner.
+            - The learner can answer casual daily questions or interview questions.
+
+            Evaluation scope:
+            - Analyze only the provided text transcript.
+            - Do not evaluate pronunciation, intonation, speaking speed, emotion, accent, microphone quality, or audio quality.
+            - Treat filler words and repeated words as text-level fluency issues only when they appear in the transcript.
+            - If the answer is unrelated, too short, or not a meaningful sentence, still return helpful Korean feedback and a model answer.
+
+            Language rules:
+            - Give all feedback, metric comments, issue explanations, and coaching text in Korean.
+            - If the learner answered in English, improvedText must be a natural English model answer.
+            - If the learner answered in Korean, improvedText must be a natural Korean model answer.
+            - If the question is for English speaking practice and the learner answered in Korean, explain in Korean that an English answer is recommended, then provide an English improvedText.
+            - Do not shame the learner. Be specific, practical, and encouraging.
+
+            Scoring rules:
+            - Scores must be integers from 0 to 100.
+            - overallScore should reflect answer usefulness, clarity, naturalness, and relevance.
+            - Always include exactly four metrics in this order:
+              1. fluency, label: 유창성
+              2. vocabulary, label: 어휘
+              3. structure, label: 문장 구성
+              4. relevance, label: 질문 적합성
+            - Metric comments must be short Korean sentences.
+            - A very short, unrelated, or non-answer transcript should receive a low relevance score.
+
+            Issue rules:
+            - Return issues only for concrete improvements visible in the transcript.
+            - Use issue types only from:
+              FILLER, REPETITION, AWKWARD_EXPRESSION, GRAMMAR, TOO_LONG, UNCLEAR, STRUCTURE
+            - startIndex is inclusive and endIndex is exclusive, based on Java string indexing of the original learner answer.
+            - original must exactly match the substring when possible.
+            - If the exact substring cannot be safely located, set highlightable=false and use startIndex=0, endIndex=0.
+            - suggestion must be concise and directly usable.
+            - explanation must be Korean.
+
+            Rendering rules:
+            - renderBlocks are used by the frontend for red to blue correction rendering.
+            - Use red blocks for original phrases that should be improved.
+            - Use blue blocks for improved phrases.
+            - Use normal blocks for unchanged context.
+            - If an issue is not highlightable, do not create a red block for it.
+            - issueIndex must point to the related issue index when kind is original or improved.
+
+            Output rules:
+            - Return only valid JSON.
+            - Do not wrap JSON in markdown.
+            - Do not add explanations outside JSON.
+            - Do not include trailing commas.
+            - Do not include fields outside the schema.
+
+            JSON schema:
+            {
+              "improvedText": "string",
+              "feedback": {
+                "overallScore": 0,
+                "overallComment": "string",
+                "metrics": [
+                  {
+                    "key": "fluency | vocabulary | structure | relevance",
+                    "label": "string",
+                    "score": 0,
+                    "comment": "string"
+                  }
+                ]
+              },
+              "issues": [
                 {
-                  "improvedText": "string",
-                  "issues": [
-                    {
-                      "type": "FILLER | REPETITION | AWKWARD_EXPRESSION | GRAMMAR | TOO_LONG | UNCLEAR | STRUCTURE",
-                      "startIndex": 0,
-                      "endIndex": 0,
-                      "original": "string",
-                      "suggestion": "string",
-                      "explanation": "string",
-                      "highlightable": true
-                    }
-                  ],
-                  "renderBlocks": [
-                    {
-                      "kind": "original | improved | normal",
-                      "text": "string",
-                      "color": "red | blue | none",
-                      "issueIndex": 0
-                    }
-                  ]
+                  "type": "FILLER | REPETITION | AWKWARD_EXPRESSION | GRAMMAR | TOO_LONG | UNCLEAR | STRUCTURE",
+                  "startIndex": 0,
+                  "endIndex": 0,
+                  "original": "string",
+                  "suggestion": "string",
+                  "explanation": "string",
+                  "highlightable": true
                 }
+              ],
+              "renderBlocks": [
+                {
+                  "kind": "original | improved | normal",
+                  "text": "string",
+                  "color": "red | blue | none",
+                  "issueIndex": 0
+                }
+              ]
+            }
+            """;
 
-                Rendering rule:
-                - Use red blocks for the original phrase that should be improved.
-                - Use blue blocks for the improved phrase.
-                - Use highlightable=false if an issue should be saved but cannot be safely highlighted.
+    private static final String VARIABLE_INPUT_TEMPLATE = """
 
-                Question:
-                %s
+            %s
 
-                Learner answer:
-                %s
-                """.formatted(question, transcript);
+            Question:
+            %s
+
+            Learner answer:
+            %s
+            """;
+
+    public String build(String question, String transcript) {
+        return CACHEABLE_INSTRUCTION_PREFIX + VARIABLE_INPUT_TEMPLATE.formatted(
+                VARIABLE_INPUT_MARKER,
+                question,
+                transcript
+        );
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/LlmAnalysisPort.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/LlmAnalysisPort.java
@@ -9,7 +9,8 @@ public interface LlmAnalysisPort {
     record LlmAnalysisResult(
             String improvedText,
             List<Issue> issues,
-            List<RenderBlock> renderBlocks
+            List<RenderBlock> renderBlocks,
+            Feedback feedback
     ) {
     }
 
@@ -29,6 +30,21 @@ public interface LlmAnalysisPort {
             String text,
             String color,
             Integer issueIndex
+    ) {
+    }
+
+    record Feedback(
+            int overallScore,
+            String overallComment,
+            List<Metric> metrics
+    ) {
+    }
+
+    record Metric(
+            String key,
+            String label,
+            int score,
+            String comment
     ) {
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/MockGeminiAnalysisAdapter.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/MockGeminiAnalysisAdapter.java
@@ -17,7 +17,17 @@ public class MockGeminiAnalysisAdapter implements LlmAnalysisPort {
         return new LlmAnalysisResult(
                 improved,
                 List.of(),
-                List.of(new RenderBlock("improved", improved, "blue", null))
+                List.of(new RenderBlock("improved", improved, "blue", null)),
+                new Feedback(
+                        80,
+                        "답변을 잘 완성했어요. 개선 답변을 보며 한 번 더 말해보세요.",
+                        List.of(
+                                new Metric("fluency", "유창성", 80, "흐름이 자연스러운 편이에요."),
+                                new Metric("vocabulary", "어휘", 80, "핵심 표현을 잘 사용했어요."),
+                                new Metric("structure", "답변 구성", 80, "답변 구조가 이해하기 쉬워요."),
+                                new Metric("relevance", "질문 적합도", 80, "질문에 잘 맞는 답변이에요.")
+                        )
+                )
         );
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/ObjectKeyGenerator.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/ObjectKeyGenerator.java
@@ -25,7 +25,8 @@ public class ObjectKeyGenerator {
     }
 
     private String extension(String mimeType) {
-        return switch (mimeType.toLowerCase(Locale.ROOT)) {
+        String normalized = mimeType == null ? "" : mimeType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+        return switch (normalized) {
             case "audio/webm" -> "webm";
             case "audio/mp4" -> "mp4";
             case "audio/ogg" -> "ogg";

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/ProgressService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/ProgressService.java
@@ -32,7 +32,7 @@ public class ProgressService {
         return switch (status) {
             case PENDING_ANALYSIS -> 55;
             case ANALYZING -> 70;
-            case COMPLETED, FAILED -> 100;
+            case COMPLETED, RECORDED, FAILED -> 100;
         };
     }
 

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/SpeakingRecordService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/SpeakingRecordService.java
@@ -9,6 +9,8 @@ import com.lbs.speaking.speaking.infrastructure.entity.AnalysisEntity;
 import com.lbs.speaking.speaking.infrastructure.entity.DailyQuestionEntity;
 import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordEntity;
 import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordStatus;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordType;
 import com.lbs.speaking.speaking.infrastructure.repository.AnalysisJpaRepository;
 import com.lbs.speaking.speaking.infrastructure.repository.DailyQuestionJpaRepository;
 import com.lbs.speaking.speaking.infrastructure.repository.SpeakingRecordJpaRepository;
@@ -16,6 +18,7 @@ import com.lbs.speaking.speaking.worker.AnalysisPublisher;
 import com.lbs.speaking.speaking.worker.AnalysisRequestedEvent;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -37,29 +40,60 @@ public class SpeakingRecordService {
     private final ObjectKeyGenerator objectKeyGenerator;
     private final ProgressService progressService;
     private final AnalysisPublisher analysisPublisher;
-    private final ReanalysisLimitService reanalysisLimitService;
+    private final AnalysisLimitService analysisLimitService;
 
     @Transactional
     public SpeakingDtos.TodayQuestionResponse getTodayQuestion() {
-        DailyQuestionEntity dailyQuestion = todayQuestionService.getOrCreateTodayQuestion();
+        return getQuestion(SpeakingQuestionType.DAILY);
+    }
+
+    @Transactional
+    public SpeakingDtos.TodayQuestionResponse getInterviewQuestion() {
+        return getQuestion(SpeakingQuestionType.INTERVIEW);
+    }
+
+    private SpeakingDtos.TodayQuestionResponse getQuestion(SpeakingQuestionType questionType) {
+        DailyQuestionEntity dailyQuestion = todayQuestionService.getOrCreateTodayQuestion(questionType);
         return new SpeakingDtos.TodayQuestionResponse(
                 dailyQuestion.getId(),
                 dailyQuestion.getQuestionDate(),
                 dailyQuestion.getQuestion().getId(),
-                dailyQuestion.getQuestion().getContent()
+                dailyQuestion.getQuestion().getContent(),
+                dailyQuestion.getQuestionType()
         );
     }
 
     @Transactional
     public SpeakingDtos.PresignedUploadResponse createUploadUrl(Long userId,
                                                                 SpeakingDtos.PresignedUploadRequest request) {
-        validateAudio(request.mimeType(), request.sizeBytes(), request.durationSec());
-        DailyQuestionEntity dailyQuestion = todayQuestionService.getOrCreateTodayQuestion();
+        String mimeType = normalizeMimeType(request.mimeType());
+        validateAudio(mimeType, request.sizeBytes(), request.durationSec());
+        DailyQuestionEntity dailyQuestion = todayQuestionService.getOrCreateTodayQuestion(resolveQuestionType(request));
 
         String uploadId = UUID.randomUUID().toString();
-        String objectKey = objectKeyGenerator.tempKey(userId, uploadId, request.mimeType());
+        String objectKey = objectKeyGenerator.tempKey(userId, uploadId, mimeType);
         uploadSessionService.create(uploadId, userId, dailyQuestion.getId(), objectKey,
-                request.mimeType(), request.sizeBytes(), request.durationSec());
+                mimeType, request.sizeBytes(), request.durationSec());
+
+        String uploadUrl = audioStorageService.createUploadUrl(objectKey);
+        return new SpeakingDtos.PresignedUploadResponse(
+                uploadId,
+                uploadUrl,
+                objectKey,
+                minioProperties.presignedPutExpiryMinutes() * 60
+        );
+    }
+
+    @Transactional
+    public SpeakingDtos.PresignedUploadResponse createCustomUploadUrl(Long userId,
+                                                                      SpeakingDtos.PresignedUploadRequest request) {
+        String mimeType = normalizeMimeType(request.mimeType());
+        validateAudio(mimeType, request.sizeBytes(), request.durationSec());
+
+        String uploadId = UUID.randomUUID().toString();
+        String objectKey = objectKeyGenerator.tempKey(userId, uploadId, mimeType);
+        uploadSessionService.create(uploadId, userId, null, objectKey,
+                mimeType, request.sizeBytes(), request.durationSec());
 
         String uploadUrl = audioStorageService.createUploadUrl(objectKey);
         return new SpeakingDtos.PresignedUploadResponse(
@@ -80,6 +114,7 @@ public class SpeakingRecordService {
         if (recordRepository.existsByUserIdAndDailyQuestionIdAndDeletedAtIsNull(userId, dailyQuestion.getId())) {
             throw new BusinessException(ErrorCode.DUPLICATE_DAILY_ANSWER);
         }
+        analysisLimitService.acquire(userId, LocalDate.now(properties.zoneId()));
 
         audioStorageService.assertExists(session.objectKey());
         SpeakingRecordEntity record = savePendingRecord(userId, dailyQuestion, request.transcript(), session);
@@ -92,7 +127,32 @@ public class SpeakingRecordService {
         record.markAnalyzing(permanentObjectKey);
         progressService.setProgress(record.getId(), 70);
         uploadSessionService.delete(session.uploadId());
-        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, 1));
+        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, 1, false));
+        return toRecordResponse(record);
+    }
+
+    @Transactional
+    public SpeakingDtos.RecordResponse createCustomRecord(Long userId, SpeakingDtos.CreateCustomRecordRequest request) {
+        UploadSession session = uploadSessionService.getRequired(request.uploadId());
+        validateSession(userId, request.objectKey(), session);
+
+        audioStorageService.assertExists(session.objectKey());
+        SpeakingRecordEntity record = recordRepository.save(SpeakingRecordEntity.createRecordedCustomText(
+                userId,
+                request.promptText(),
+                session.objectKey(),
+                request.transcript(),
+                session.mimeType(),
+                session.sizeBytes(),
+                session.durationSec()
+        ));
+
+        String permanentObjectKey = objectKeyGenerator.permanentKey(userId, record.getId(), session.mimeType());
+        audioStorageService.copy(session.objectKey(), permanentObjectKey);
+        audioStorageService.delete(session.objectKey());
+
+        record.markRecorded(permanentObjectKey);
+        uploadSessionService.delete(session.uploadId());
         return toRecordResponse(record);
     }
 
@@ -132,7 +192,8 @@ public class SpeakingRecordService {
                 .stream()
                 .map(record -> new SpeakingDtos.RecordListItemResponse(
                         record.getId(),
-                        record.getDailyQuestion().getQuestion().getContent(),
+                        questionText(record),
+                        record.getRecordType(),
                         record.getStatus(),
                         record.getCreatedAt()
                 ))
@@ -150,10 +211,10 @@ public class SpeakingRecordService {
     @Transactional
     public SpeakingDtos.RecordResponse reanalyze(Long userId, Long recordId) {
         SpeakingRecordEntity record = getOwnedRecord(userId, recordId);
-        int attempt = reanalysisLimitService.acquire(userId, recordId, LocalDate.now(properties.zoneId()));
+        analysisLimitService.acquire(userId, LocalDate.now(properties.zoneId()));
         record.markAnalyzing(record.getObjectKey());
         progressService.setProgress(record.getId(), 70);
-        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, attempt));
+        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, 1, true));
         return toRecordResponse(record);
     }
 
@@ -185,6 +246,17 @@ public class SpeakingRecordService {
         }
     }
 
+    private SpeakingQuestionType resolveQuestionType(SpeakingDtos.PresignedUploadRequest request) {
+        return request.questionType() == null ? SpeakingQuestionType.DAILY : request.questionType();
+    }
+
+    private String normalizeMimeType(String mimeType) {
+        if (mimeType == null) {
+            return "";
+        }
+        return mimeType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+    }
+
     private void validateSession(Long userId, String objectKey, UploadSession session) {
         if (!session.userId().equals(userId) || !session.objectKey().equals(objectKey)) {
             throw new BusinessException(ErrorCode.INVALID_UPLOAD_SESSION);
@@ -196,20 +268,29 @@ public class SpeakingRecordService {
                 .map(entity -> new SpeakingDtos.AnalysisResponse(
                         entity.getImprovedText(),
                         entity.getIssuesJson(),
-                        entity.getRenderBlocksJson()
+                        entity.getRenderBlocksJson(),
+                        entity.getFeedbackJson()
                 ))
                 .orElse(null);
 
         return new SpeakingDtos.RecordResponse(
                 record.getId(),
-                record.getDailyQuestion().getId(),
-                record.getDailyQuestion().getQuestion().getContent(),
+                record.getDailyQuestion() == null ? null : record.getDailyQuestion().getId(),
+                questionText(record),
+                record.getRecordType(),
                 record.getOriginalText(),
                 record.getStatus(),
                 record.getFailureReason(),
                 record.getCreatedAt(),
                 analysis
         );
+    }
+
+    private String questionText(SpeakingRecordEntity record) {
+        if (record.getRecordType() == SpeakingRecordType.CUSTOM_TEXT) {
+            return record.getPromptText();
+        }
+        return record.getDailyQuestion().getQuestion().getContent();
     }
 
     private String progressMessage(SpeakingRecordStatus status, int progress) {

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/TodayQuestionService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/TodayQuestionService.java
@@ -5,6 +5,7 @@ import com.lbs.speaking.common.response.ErrorCode;
 import com.lbs.speaking.config.SpeakingProperties;
 import com.lbs.speaking.speaking.infrastructure.entity.DailyQuestionEntity;
 import com.lbs.speaking.speaking.infrastructure.entity.QuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
 import com.lbs.speaking.speaking.infrastructure.repository.DailyQuestionJpaRepository;
 import com.lbs.speaking.speaking.infrastructure.repository.QuestionJpaRepository;
 import java.time.Duration;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TodayQuestionService {
 
+    private static final String INTERVIEW_CATEGORY = "Interview";
+
     private final DailyQuestionJpaRepository dailyQuestionRepository;
     private final QuestionJpaRepository questionRepository;
     private final RedisLockService redisLockService;
@@ -27,42 +30,57 @@ public class TodayQuestionService {
 
     @Transactional
     public DailyQuestionEntity getOrCreateTodayQuestion() {
+        return getOrCreateTodayQuestion(SpeakingQuestionType.DAILY);
+    }
+
+    @Transactional
+    public DailyQuestionEntity getOrCreateTodayQuestion(SpeakingQuestionType questionType) {
         LocalDate today = LocalDate.now(properties.zoneId());
-        return dailyQuestionRepository.findByQuestionDate(today)
+        return dailyQuestionRepository.findByQuestionDateAndQuestionType(today, questionType)
                 .orElseGet(() -> redisLockService.withLock(
-                        "speaking:lock:daily-question:" + today,
+                        "speaking:lock:daily-question:" + questionType + ":" + today,
                         Duration.ofSeconds(5),
-                        () -> createTodayQuestion(today),
-                        () -> dailyQuestionRepository.findByQuestionDate(today)
-                                .orElseGet(() -> createTodayQuestion(today))
+                        () -> createTodayQuestion(today, questionType),
+                        () -> dailyQuestionRepository.findByQuestionDateAndQuestionType(today, questionType)
+                                .orElseGet(() -> createTodayQuestion(today, questionType))
                 ));
     }
 
-    private DailyQuestionEntity createTodayQuestion(LocalDate today) {
-        return dailyQuestionRepository.findByQuestionDate(today)
+    private DailyQuestionEntity createTodayQuestion(LocalDate today, SpeakingQuestionType questionType) {
+        return dailyQuestionRepository.findByQuestionDateAndQuestionType(today, questionType)
                 .orElseGet(() -> {
                     try {
-                        QuestionEntity question = pickCandidate();
-                        return dailyQuestionRepository.save(DailyQuestionEntity.create(today, question));
+                        QuestionEntity question = pickCandidate(questionType);
+                        return dailyQuestionRepository.save(DailyQuestionEntity.create(today, questionType, question));
                     } catch (DataIntegrityViolationException exception) {
-                        return dailyQuestionRepository.findByQuestionDate(today)
+                        return dailyQuestionRepository.findByQuestionDateAndQuestionType(today, questionType)
                                 .orElseThrow(() -> exception);
                     }
                 });
     }
 
-    private QuestionEntity pickCandidate() {
-        List<Long> usedIds = dailyQuestionRepository.findUsedQuestionIds();
-        List<QuestionEntity> candidates = usedIds.isEmpty()
-                ? questionRepository.findByActiveTrue()
-                : questionRepository.findByActiveTrueAndIdNotIn(usedIds);
+    private QuestionEntity pickCandidate(SpeakingQuestionType questionType) {
+        List<Long> usedIds = dailyQuestionRepository.findUsedQuestionIds(questionType);
+        List<QuestionEntity> candidates = findCandidates(questionType, usedIds);
 
         if (candidates.isEmpty()) {
-            candidates = questionRepository.findByActiveTrue();
+            candidates = findCandidates(questionType, List.of());
         }
         if (candidates.isEmpty()) {
             throw new BusinessException(ErrorCode.TODAY_QUESTION_NOT_FOUND);
         }
         return candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+    }
+
+    private List<QuestionEntity> findCandidates(SpeakingQuestionType questionType, List<Long> excludedIds) {
+        boolean hasExcluded = !excludedIds.isEmpty();
+        if (questionType == SpeakingQuestionType.INTERVIEW) {
+            return hasExcluded
+                    ? questionRepository.findByActiveTrueAndCategory_NameAndIdNotIn(INTERVIEW_CATEGORY, excludedIds)
+                    : questionRepository.findByActiveTrueAndCategory_Name(INTERVIEW_CATEGORY);
+        }
+        return hasExcluded
+                ? questionRepository.findByActiveTrueAndCategory_NameNotAndIdNotIn(INTERVIEW_CATEGORY, excludedIds)
+                : questionRepository.findByActiveTrueAndCategory_NameNot(INTERVIEW_CATEGORY);
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisRequestedEvent.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisRequestedEvent.java
@@ -1,4 +1,8 @@
 package com.lbs.speaking.speaking.worker;
 
-public record AnalysisRequestedEvent(Long recordId, Long userId, int attempt) {
+public record AnalysisRequestedEvent(Long recordId, Long userId, int attempt, boolean force) {
+
+    public AnalysisRequestedEvent(Long recordId, Long userId, int attempt) {
+        this(recordId, userId, attempt, false);
+    }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisWorker.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisWorker.java
@@ -26,12 +26,12 @@ public class AnalysisWorker {
     public void handle(AnalysisRequestedEvent event, Channel channel,
                        @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag) throws Exception {
         try {
-            processingService.process(event.recordId());
+            processingService.process(event.recordId(), event.force());
             channel.basicAck(deliveryTag, false);
         } catch (Exception exception) {
             log.warn("Speaking analysis failed. recordId={}", event.recordId(), exception);
             if (event.attempt() < MAX_ATTEMPT) {
-                analysisPublisher.publish(new AnalysisRequestedEvent(event.recordId(), event.userId(), event.attempt() + 1));
+                analysisPublisher.publish(new AnalysisRequestedEvent(event.recordId(), event.userId(), event.attempt() + 1, event.force()));
             } else {
                 processingService.fail(event.recordId(), exception.getMessage());
             }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/SpeakingJobs.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/SpeakingJobs.java
@@ -41,7 +41,7 @@ public class SpeakingJobs {
                     )
                     .stream()
                     .filter(record -> !analysisRepository.existsByRecordId(record.getId()))
-                    .forEach(record -> analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), record.getUserId(), 1)));
+                    .forEach(record -> analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), record.getUserId(), 1, false)));
         } finally {
             redisLockService.unlock(lockKey);
         }

--- a/SpeakingService/src/main/resources/db/migration/V2__add_speaking_question_types.sql
+++ b/SpeakingService/src/main/resources/db/migration/V2__add_speaking_question_types.sql
@@ -1,0 +1,49 @@
+ALTER TABLE speaking_daily_questions
+    ADD COLUMN question_type VARCHAR(30) NOT NULL DEFAULT 'DAILY' AFTER question_date;
+
+ALTER TABLE speaking_daily_questions
+    DROP INDEX uk_speaking_daily_question_date;
+
+ALTER TABLE speaking_daily_questions
+    ADD CONSTRAINT uk_speaking_daily_question_date_type UNIQUE (question_date, question_type);
+
+INSERT INTO speaking_question_categories (name, created_at, updated_at)
+SELECT 'Interview', NOW(6), NOW(6)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM speaking_question_categories
+    WHERE name = 'Interview'
+);
+
+INSERT INTO speaking_questions (category_id, content, active, created_at, updated_at)
+SELECT c.id, 'What is one small win you had recently, and why did it matter to you?', 1, NOW(6), NOW(6)
+FROM speaking_question_categories c
+WHERE c.name = 'Daily Life'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM speaking_questions
+      WHERE content = 'What is one small win you had recently, and why did it matter to you?'
+  );
+
+INSERT INTO speaking_questions (category_id, content, active, created_at, updated_at)
+SELECT c.id, q.content, 1, NOW(6), NOW(6)
+FROM speaking_question_categories c
+JOIN (
+    SELECT 'Tell me about yourself and your background.' AS content
+    UNION ALL
+    SELECT 'Why are you interested in this position?'
+    UNION ALL
+    SELECT 'Describe a challenging project you worked on and how you handled it.'
+    UNION ALL
+    SELECT 'Tell me about a time you received difficult feedback.'
+    UNION ALL
+    SELECT 'What are your strengths, and how do they help your team?'
+    UNION ALL
+    SELECT 'Where do you want to grow professionally over the next year?'
+) q
+WHERE c.name = 'Interview'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM speaking_questions
+      WHERE content = q.content
+  );

--- a/SpeakingService/src/main/resources/db/migration/V3__localize_speaking_questions.sql
+++ b/SpeakingService/src/main/resources/db/migration/V3__localize_speaking_questions.sql
@@ -1,0 +1,51 @@
+UPDATE speaking_questions
+SET content = '올해 가장 크게 성장하는 데 도움이 된 습관은 무엇인가요?'
+WHERE content = 'What habit helped you grow the most this year?';
+
+UPDATE speaking_questions
+SET content = '하루를 더 좋게 만들어 주는 작은 루틴을 설명해 주세요.'
+WHERE content = 'Describe a small routine that makes your day better.';
+
+UPDATE speaking_questions
+SET content = '당신에게 유용한 배움을 준 실수 하나를 이야기해 주세요.'
+WHERE content = 'What is one mistake that taught you something useful?';
+
+UPDATE speaking_questions
+SET content = '올해 어떤 사람으로 성장하고 싶은지 이야기해 주세요.'
+WHERE content = 'What kind of person do you want to become this year?';
+
+UPDATE speaking_questions
+SET content = '현재 향상시키려고 노력 중인 기술에 대해 이야기해 주세요.'
+WHERE content = 'Tell me about a skill you are currently trying to improve.';
+
+UPDATE speaking_questions
+SET content = '어려운 과제를 맡았을 때 집중력을 어떻게 유지하나요?'
+WHERE content = 'How do you stay focused when a task is difficult?';
+
+UPDATE speaking_questions
+SET content = '최근에 얻은 작은 성과는 무엇이고, 왜 의미가 있었나요?'
+WHERE content = 'What is one small win you had recently, and why did it matter to you?';
+
+UPDATE speaking_questions
+SET content = '자기소개와 지금까지의 경험을 간단히 이야기해 주세요.'
+WHERE content = 'Tell me about yourself and your background.';
+
+UPDATE speaking_questions
+SET content = '이 직무에 관심을 갖게 된 이유는 무엇인가요?'
+WHERE content = 'Why are you interested in this position?';
+
+UPDATE speaking_questions
+SET content = '어려웠던 프로젝트 하나와 그것을 어떻게 해결했는지 설명해 주세요.'
+WHERE content = 'Describe a challenging project you worked on and how you handled it.';
+
+UPDATE speaking_questions
+SET content = '받기 어려웠던 피드백을 들었던 경험과 그 이후의 행동을 이야기해 주세요.'
+WHERE content = 'Tell me about a time you received difficult feedback.';
+
+UPDATE speaking_questions
+SET content = '본인의 강점은 무엇이고, 그 강점이 팀에 어떻게 도움이 되나요?'
+WHERE content = 'What are your strengths, and how do they help your team?';
+
+UPDATE speaking_questions
+SET content = '앞으로 1년 동안 직무적으로 어떤 부분을 성장시키고 싶나요?'
+WHERE content = 'Where do you want to grow professionally over the next year?';

--- a/SpeakingService/src/main/resources/db/migration/V4__add_speaking_analysis_feedback.sql
+++ b/SpeakingService/src/main/resources/db/migration/V4__add_speaking_analysis_feedback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE speaking_analyses
+    ADD COLUMN feedback_json JSON NULL AFTER render_blocks_json;

--- a/SpeakingService/src/main/resources/db/migration/V5__add_custom_speaking_records.sql
+++ b/SpeakingService/src/main/resources/db/migration/V5__add_custom_speaking_records.sql
@@ -1,0 +1,6 @@
+ALTER TABLE speaking_records
+    ADD COLUMN record_type VARCHAR(30) NOT NULL DEFAULT 'QUESTION_ANALYSIS' AFTER daily_question_id,
+    ADD COLUMN prompt_text TEXT NULL AFTER record_type;
+
+ALTER TABLE speaking_records
+    MODIFY daily_question_id BIGINT NULL;

--- a/SpeakingService/src/test/java/com/lbs/speaking/config/RabbitConfigTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/config/RabbitConfigTest.java
@@ -31,7 +31,7 @@ class RabbitConfigTest {
                     "speaking.analysis.failed"
             ),
             new SpeakingProperties.Jobs("0 */10 * * * *", "0 0 * * * *", 15, 24),
-            new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash", 30)
+            new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash-lite", 30)
     );
 
     @Test

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/controller/SpeakingControllerTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/controller/SpeakingControllerTest.java
@@ -17,6 +17,7 @@ import com.lbs.speaking.common.exception.BusinessException;
 import com.lbs.speaking.common.response.ErrorCode;
 import com.lbs.speaking.speaking.dto.SpeakingDtos;
 import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordStatus;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordType;
 import com.lbs.speaking.speaking.service.SpeakingRecordService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -66,6 +67,24 @@ class SpeakingControllerTest {
                 .andExpect(jsonPath("$.data.dailyQuestionId").value(10))
                 .andExpect(jsonPath("$.data.questionId").value(20))
                 .andExpect(jsonPath("$.data.content").value("What did you learn today?"));
+    }
+
+    @Test
+    @DisplayName("GET /speaking/interview/today returns today's interview question")
+    void getInterviewQuestion() throws Exception {
+        given(speakingRecordService.getInterviewQuestion()).willReturn(new SpeakingDtos.TodayQuestionResponse(
+                11L,
+                LocalDate.of(2026, 5, 12),
+                21L,
+                "Tell me about yourself and your background.",
+                com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType.INTERVIEW
+        ));
+
+        mockMvc.perform(get("/speaking/interview/today"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.dailyQuestionId").value(11))
+                .andExpect(jsonPath("$.data.questionType").value("INTERVIEW"))
+                .andExpect(jsonPath("$.data.content").value("Tell me about yourself and your background."));
     }
 
     @Test
@@ -148,6 +167,31 @@ class SpeakingControllerTest {
     }
 
     @Test
+    @DisplayName("custom presigned upload response does not require a daily question")
+    void createCustomPresignedUploadUrl() throws Exception {
+        given(jwtTokenProvider.resolveUserId(AUTHORIZATION)).willReturn(USER_ID);
+        given(speakingRecordService.createCustomUploadUrl(eq(USER_ID), any()))
+                .willReturn(new SpeakingDtos.PresignedUploadResponse(
+                        "upload-custom-1",
+                        "https://evil55.cloud/speaking-audio/speaking/temp/7/upload-custom-1.webm",
+                        "speaking/temp/7/upload-custom-1.webm",
+                        600
+                ));
+
+        mockMvc.perform(post("/speaking/custom/uploads/presigned-url")
+                        .header("Authorization", AUTHORIZATION)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SpeakingDtos.PresignedUploadRequest(
+                                "audio/webm",
+                                1024,
+                                30
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploadId").value("upload-custom-1"))
+                .andExpect(jsonPath("$.data.objectKey").value("speaking/temp/7/upload-custom-1.webm"));
+    }
+
+    @Test
     @DisplayName("record creation returns 201")
     void createRecord() throws Exception {
         given(jwtTokenProvider.resolveUserId(AUTHORIZATION)).willReturn(USER_ID);
@@ -169,6 +213,39 @@ class SpeakingControllerTest {
     }
 
     @Test
+    @DisplayName("custom record creation returns a recorded record without analysis")
+    void createCustomRecord() throws Exception {
+        given(jwtTokenProvider.resolveUserId(AUTHORIZATION)).willReturn(USER_ID);
+        given(speakingRecordService.createCustomRecord(eq(USER_ID), any()))
+                .willReturn(new SpeakingDtos.RecordResponse(
+                        2L,
+                        null,
+                        "내가 쓴 발표문",
+                        SpeakingRecordType.CUSTOM_TEXT,
+                        "내가 쓴 발표문",
+                        SpeakingRecordStatus.RECORDED,
+                        null,
+                        LocalDateTime.of(2026, 5, 12, 10, 0),
+                        null
+                ));
+
+        mockMvc.perform(post("/speaking/custom/records")
+                        .header("Authorization", AUTHORIZATION)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SpeakingDtos.CreateCustomRecordRequest(
+                                "upload-custom-1",
+                                "speaking/temp/7/upload-custom-1.webm",
+                                "내가 쓴 발표문",
+                                "내가 쓴 발표문"
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.dailyQuestionId").doesNotExist())
+                .andExpect(jsonPath("$.data.recordType").value("CUSTOM_TEXT"))
+                .andExpect(jsonPath("$.data.status").value("RECORDED"))
+                .andExpect(jsonPath("$.data.analysis").doesNotExist());
+    }
+
+    @Test
     @DisplayName("duplicate daily answer returns 409")
     void duplicateDailyAnswer() throws Exception {
         given(jwtTokenProvider.resolveUserId(AUTHORIZATION)).willReturn(USER_ID);
@@ -185,6 +262,25 @@ class SpeakingControllerTest {
                         ))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("DUPLICATE_DAILY_ANSWER"));
+    }
+
+    @Test
+    @DisplayName("daily analysis limit returns 429")
+    void analysisLimitExceeded() throws Exception {
+        given(jwtTokenProvider.resolveUserId(AUTHORIZATION)).willReturn(USER_ID);
+        given(speakingRecordService.createRecord(eq(USER_ID), any()))
+                .willThrow(new BusinessException(ErrorCode.ANALYSIS_LIMIT_EXCEEDED));
+
+        mockMvc.perform(post("/speaking/records")
+                        .header("Authorization", AUTHORIZATION)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SpeakingDtos.CreateRecordRequest(
+                                "upload-1",
+                                "speaking/temp/7/upload-1.webm",
+                                "I already analyzed five times."
+                        ))))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.errorCode").value("ANALYSIS_LIMIT_EXCEEDED"));
     }
 
     @Test
@@ -247,6 +343,7 @@ class SpeakingControllerTest {
                 1L,
                 10L,
                 "What did you learn today?",
+                SpeakingRecordType.QUESTION_ANALYSIS,
                 "I learned queue based analysis today.",
                 status,
                 null,

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisLimitServiceTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisLimitServiceTest.java
@@ -15,19 +15,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-class ReanalysisLimitServiceTest {
+class AnalysisLimitServiceTest {
 
     private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
     private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
-    private final ReanalysisLimitService limitService = new ReanalysisLimitService(redisTemplate);
+    private final AnalysisLimitService limitService = new AnalysisLimitService(redisTemplate);
 
     @Test
-    void incrementsDailyCounterAndSetsTtlOnFirstAttempt() {
-        String key = "speaking:reanalyze:2:10:2026-05-12";
+    void incrementsDailyCounterByUserAndSetsTtlOnFirstAttempt() {
+        String key = "speaking:analysis:2:2026-05-12";
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.increment(key)).thenReturn(1L);
 
-        int attempt = limitService.acquire(2L, 10L, LocalDate.of(2026, 5, 12));
+        int attempt = limitService.acquire(2L, LocalDate.of(2026, 5, 12));
 
         assertThat(attempt).isEqualTo(1);
         verify(redisTemplate).expire(key, Duration.ofDays(2));
@@ -35,23 +35,23 @@ class ReanalysisLimitServiceTest {
 
     @Test
     void throwsWhenDailyLimitIsExceeded() {
-        String key = "speaking:reanalyze:2:10:2026-05-12";
+        String key = "speaking:analysis:2:2026-05-12";
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.increment(key)).thenReturn(6L);
 
-        assertThatThrownBy(() -> limitService.acquire(2L, 10L, LocalDate.of(2026, 5, 12)))
+        assertThatThrownBy(() -> limitService.acquire(2L, LocalDate.of(2026, 5, 12)))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.REANALYZE_LIMIT_EXCEEDED);
+                .isEqualTo(ErrorCode.ANALYSIS_LIMIT_EXCEEDED);
     }
 
     @Test
     void allowsFifthAttemptWithoutResettingTtl() {
-        String key = "speaking:reanalyze:2:10:2026-05-12";
+        String key = "speaking:analysis:2:2026-05-12";
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.increment(key)).thenReturn(5L);
 
-        int attempt = limitService.acquire(2L, 10L, LocalDate.of(2026, 5, 12));
+        int attempt = limitService.acquire(2L, LocalDate.of(2026, 5, 12));
 
         assertThat(attempt).isEqualTo(5);
         verify(redisTemplate, never()).expire(key, Duration.ofDays(2));
@@ -59,11 +59,11 @@ class ReanalysisLimitServiceTest {
 
     @Test
     void treatsNullIncrementResultAsFirstAttempt() {
-        String key = "speaking:reanalyze:2:10:2026-05-12";
+        String key = "speaking:analysis:2:2026-05-12";
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.increment(key)).thenReturn(null);
 
-        int attempt = limitService.acquire(2L, 10L, LocalDate.of(2026, 5, 12));
+        int attempt = limitService.acquire(2L, LocalDate.of(2026, 5, 12));
 
         assertThat(attempt).isEqualTo(1);
         verify(redisTemplate, never()).expire(key, Duration.ofDays(2));

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisProcessingServiceTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisProcessingServiceTest.java
@@ -51,6 +51,32 @@ class AnalysisProcessingServiceTest {
     }
 
     @Test
+    void forceProcessReplacesExistingAnalysisEvenWhenRecordIsCompleted() {
+        SpeakingRecordEntity record = record(10L, SpeakingRecordStatus.COMPLETED);
+        AnalysisEntity existingAnalysis = AnalysisEntity.create(record, "old", "[]", "[]", "{}");
+        LlmAnalysisPort.RenderBlock block = new LlmAnalysisPort.RenderBlock("improved", "I went", "blue", 0);
+        LlmAnalysisPort.LlmAnalysisResult result = new LlmAnalysisPort.LlmAnalysisResult(
+                "I went home again.",
+                List.of(),
+                List.of(block),
+                new LlmAnalysisPort.Feedback(90, "좋아요.", List.of())
+        );
+        when(recordRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(record));
+        when(llmAnalysisPort.analyze("What did you do today?", "I go home.")).thenReturn(result);
+        when(issueIndexCorrector.correct("I go home.", result.issues())).thenReturn(List.of());
+        when(analysisRepository.findByRecordId(10L)).thenReturn(Optional.of(existingAnalysis));
+
+        processingService.process(10L, true);
+
+        assertThat(existingAnalysis.getImprovedText()).isEqualTo("I went home again.");
+        assertThat(record.getStatus()).isEqualTo(SpeakingRecordStatus.COMPLETED);
+        verify(analysisRepository).save(existingAnalysis);
+        verify(progressService).setProgress(10L, 70);
+        verify(progressService).setProgress(10L, 90);
+        verify(progressService).setProgress(10L, 100);
+    }
+
+    @Test
     void processSavesAnalysisAndMarksRecordCompleted() {
         SpeakingRecordEntity record = record(10L, SpeakingRecordStatus.ANALYZING);
         LlmAnalysisPort.Issue issue = new LlmAnalysisPort.Issue(
@@ -66,7 +92,12 @@ class AnalysisProcessingServiceTest {
         LlmAnalysisPort.LlmAnalysisResult result = new LlmAnalysisPort.LlmAnalysisResult(
                 "I went home.",
                 List.of(issue),
-                List.of(block)
+                List.of(block),
+                new LlmAnalysisPort.Feedback(
+                        88,
+                        "답변이 더 자연스러워졌어요.",
+                        List.of(new LlmAnalysisPort.Metric("fluency", "유창성", 88, "흐름이 좋아요."))
+                )
         );
         when(recordRepository.findByIdAndDeletedAtIsNull(10L)).thenReturn(Optional.of(record));
         when(llmAnalysisPort.analyze("What did you do today?", "I go home.")).thenReturn(result);
@@ -80,6 +111,7 @@ class AnalysisProcessingServiceTest {
         assertThat(analysisCaptor.getValue().getImprovedText()).isEqualTo("I went home.");
         assertThat(analysisCaptor.getValue().getIssuesJson()).contains("Past tense is needed.");
         assertThat(analysisCaptor.getValue().getRenderBlocksJson()).contains("improved");
+        assertThat(analysisCaptor.getValue().getFeedbackJson()).contains("유창성");
         assertThat(record.getStatus()).isEqualTo(SpeakingRecordStatus.COMPLETED);
         verify(progressService).setProgress(10L, 70);
         verify(progressService).setProgress(10L, 90);

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisAdapterTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisAdapterTest.java
@@ -32,7 +32,7 @@ class GeminiAnalysisAdapterTest {
                         true,
                         "https://generativelanguage.googleapis.com",
                         " ",
-                        "gemini-2.5-flash",
+                        "gemini-2.5-flash-lite",
                         30
                 )),
                 mock(GeminiPromptBuilder.class),

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisParserTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisParserTest.java
@@ -18,6 +18,13 @@ class GeminiAnalysisParserTest {
                 Sure. Here is the JSON:
                 {
                   "improvedText": "I go to school every morning.",
+                  "feedback": {
+                    "overallScore": 86,
+                    "overallComment": "답변의 핵심이 잘 드러나요.",
+                    "metrics": [
+                      {"key": "fluency", "label": "유창성", "score": 86, "comment": "흐름이 자연스러워요."}
+                    ]
+                  },
                   "issues": [
                     {
                       "type": "GRAMMAR",
@@ -43,6 +50,8 @@ class GeminiAnalysisParserTest {
         assertThat(result.issues()).hasSize(1);
         assertThat(result.issues().get(0).suggestion()).isEqualTo("go to school");
         assertThat(result.renderBlocks()).hasSize(2);
+        assertThat(result.feedback().overallScore()).isEqualTo(86);
+        assertThat(result.feedback().metrics().get(0).label()).isEqualTo("유창성");
     }
 
     @Test

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiPromptBuilderTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiPromptBuilderTest.java
@@ -16,13 +16,39 @@ class GeminiPromptBuilderTest {
         );
 
         assertThat(prompt).contains("Return only valid JSON");
-        assertThat(prompt).contains("Do not analyze pronunciation");
+        assertThat(prompt).contains("Do not evaluate pronunciation");
         assertThat(prompt).contains("\"improvedText\"");
+        assertThat(prompt).contains("\"feedback\"");
+        assertThat(prompt).contains("Give all feedback, metric comments, issue explanations, and coaching text in Korean.");
+        assertThat(prompt).contains("fluency, label:");
+        assertThat(prompt).contains("relevance, label:");
         assertThat(prompt).contains("\"issues\"");
         assertThat(prompt).contains("\"renderBlocks\"");
         assertThat(prompt).contains("red");
         assertThat(prompt).contains("blue");
+        assertThat(prompt).contains(GeminiPromptBuilder.VARIABLE_INPUT_MARKER);
         assertThat(prompt).contains("What habit helped you grow the most this year?");
         assertThat(prompt).contains("I go school every morning.");
+    }
+
+    @Test
+    void keepsInstructionPrefixStableForImplicitCacheHit() {
+        String firstPrompt = promptBuilder.build(
+                "Describe a small routine that makes your day better.",
+                "I drink coffee in the morning."
+        );
+        String secondPrompt = promptBuilder.build(
+                "Tell me about a project you are proud of.",
+                "I built a chat feature with WebSocket."
+        );
+
+        String firstPrefix = firstPrompt.substring(0, firstPrompt.indexOf(GeminiPromptBuilder.VARIABLE_INPUT_MARKER));
+        String secondPrefix = secondPrompt.substring(0, secondPrompt.indexOf(GeminiPromptBuilder.VARIABLE_INPUT_MARKER));
+
+        assertThat(firstPrefix).isEqualTo(secondPrefix);
+        assertThat(firstPrefix).doesNotContain("Describe a small routine");
+        assertThat(firstPrefix).doesNotContain("I drink coffee");
+        assertThat(secondPrefix).doesNotContain("Tell me about a project");
+        assertThat(secondPrefix).doesNotContain("I built a chat feature");
     }
 }

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/ObjectKeyGeneratorTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/ObjectKeyGeneratorTest.java
@@ -16,12 +16,19 @@ class ObjectKeyGeneratorTest {
             List.of("audio/webm"),
             new SpeakingProperties.Rabbit("exchange", "queue", "routing", "dlx", "dlq", "dlq-routing"),
             new SpeakingProperties.Jobs("0 */5 * * * *", "0 0 * * * *", 15, 24),
-            new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash", 30)
+            new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash-lite", 30)
     ));
 
     @Test
     void createsTempObjectKey() {
         String key = generator.tempKey(10L, "upload-1", "audio/webm");
+
+        assertThat(key).isEqualTo("speaking/temp/10/upload-1.webm");
+    }
+
+    @Test
+    void normalizesCodecMimeTypeWhenCreatingTempObjectKey() {
+        String key = generator.tempKey(10L, "upload-1", "audio/webm;codecs=opus");
 
         assertThat(key).isEqualTo("speaking/temp/10/upload-1.webm");
     }

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceMimeTypeTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceMimeTypeTest.java
@@ -1,0 +1,89 @@
+package com.lbs.speaking.speaking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import com.lbs.speaking.config.MinioProperties;
+import com.lbs.speaking.config.SpeakingProperties;
+import com.lbs.speaking.speaking.dto.SpeakingDtos;
+import com.lbs.speaking.speaking.infrastructure.entity.DailyQuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.QuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
+import com.lbs.speaking.speaking.infrastructure.repository.AnalysisJpaRepository;
+import com.lbs.speaking.speaking.infrastructure.repository.DailyQuestionJpaRepository;
+import com.lbs.speaking.speaking.infrastructure.repository.SpeakingRecordJpaRepository;
+import com.lbs.speaking.speaking.worker.AnalysisPublisher;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SpeakingRecordServiceMimeTypeTest {
+
+    private final SpeakingProperties speakingProperties = new SpeakingProperties(
+            "Asia/Seoul",
+            10,
+            20_971_520,
+            180,
+            List.of("audio/webm"),
+            new SpeakingProperties.Rabbit("exchange", "queue", "routing", "dlx", "dlq", "dlq-routing"),
+            new SpeakingProperties.Jobs("0 */5 * * * *", "0 0 * * * *", 15, 24),
+            new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash-lite", 30)
+    );
+
+    @Test
+    void createUploadUrlAcceptsBrowserMimeTypeWithCodecSuffix() {
+        TodayQuestionService todayQuestionService = mock(TodayQuestionService.class);
+        UploadSessionService uploadSessionService = mock(UploadSessionService.class);
+        AudioStorageService audioStorageService = mock(AudioStorageService.class);
+        DailyQuestionEntity dailyQuestion = dailyQuestion();
+        when(todayQuestionService.getOrCreateTodayQuestion(SpeakingQuestionType.DAILY)).thenReturn(dailyQuestion);
+        when(audioStorageService.createUploadUrl("speaking/temp/2/upload-1.webm")).thenReturn("https://minio.local/upload-1");
+
+        ObjectKeyGenerator objectKeyGenerator = mock(ObjectKeyGenerator.class);
+        when(objectKeyGenerator.tempKey(eq(2L), anyString(), eq("audio/webm"))).thenReturn("speaking/temp/2/upload-1.webm");
+        SpeakingRecordService service = new SpeakingRecordService(
+                speakingProperties,
+                new MinioProperties("http://localhost:9000", "http://localhost:9000", "minio", "secret", "bucket", 10, 10),
+                todayQuestionService,
+                mock(DailyQuestionJpaRepository.class),
+                mock(SpeakingRecordJpaRepository.class),
+                mock(AnalysisJpaRepository.class),
+                uploadSessionService,
+                audioStorageService,
+                objectKeyGenerator,
+                mock(ProgressService.class),
+                mock(AnalysisPublisher.class),
+                mock(AnalysisLimitService.class)
+        );
+
+        SpeakingDtos.PresignedUploadResponse response = service.createUploadUrl(
+                2L,
+                new SpeakingDtos.PresignedUploadRequest("audio/webm;codecs=opus", 1024, 30)
+        );
+
+        assertThat(response.objectKey()).isEqualTo("speaking/temp/2/upload-1.webm");
+        verify(uploadSessionService).create(
+                response.uploadId(),
+                2L,
+                5L,
+                "speaking/temp/2/upload-1.webm",
+                "audio/webm",
+                1024,
+                30
+        );
+    }
+
+    private DailyQuestionEntity dailyQuestion() {
+        QuestionEntity question = BeanUtils.instantiateClass(QuestionEntity.class);
+        ReflectionTestUtils.setField(question, "content", "What did you do today?");
+        DailyQuestionEntity dailyQuestion = DailyQuestionEntity.create(LocalDate.of(2026, 5, 13), question);
+        ReflectionTestUtils.setField(dailyQuestion, "id", 5L);
+        return dailyQuestion;
+    }
+}

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceTest.java
@@ -1,0 +1,197 @@
+package com.lbs.speaking.speaking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lbs.speaking.config.MinioProperties;
+import com.lbs.speaking.config.SpeakingProperties;
+import com.lbs.speaking.speaking.dto.SpeakingDtos;
+import com.lbs.speaking.speaking.infrastructure.entity.DailyQuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.QuestionEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingQuestionType;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordEntity;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordStatus;
+import com.lbs.speaking.speaking.infrastructure.entity.SpeakingRecordType;
+import com.lbs.speaking.speaking.infrastructure.repository.AnalysisJpaRepository;
+import com.lbs.speaking.speaking.infrastructure.repository.DailyQuestionJpaRepository;
+import com.lbs.speaking.speaking.infrastructure.repository.SpeakingRecordJpaRepository;
+import com.lbs.speaking.speaking.worker.AnalysisPublisher;
+import com.lbs.speaking.speaking.worker.AnalysisRequestedEvent;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SpeakingRecordServiceTest {
+
+    private final TodayQuestionService todayQuestionService = mock(TodayQuestionService.class);
+    private final DailyQuestionJpaRepository dailyQuestionRepository = mock(DailyQuestionJpaRepository.class);
+    private final SpeakingRecordJpaRepository recordRepository = mock(SpeakingRecordJpaRepository.class);
+    private final AnalysisJpaRepository analysisRepository = mock(AnalysisJpaRepository.class);
+    private final UploadSessionService uploadSessionService = mock(UploadSessionService.class);
+    private final AudioStorageService audioStorageService = mock(AudioStorageService.class);
+    private final ObjectKeyGenerator objectKeyGenerator = mock(ObjectKeyGenerator.class);
+    private final ProgressService progressService = mock(ProgressService.class);
+    private final AnalysisPublisher analysisPublisher = mock(AnalysisPublisher.class);
+    private final AnalysisLimitService analysisLimitService = mock(AnalysisLimitService.class);
+    private final SpeakingRecordService service = new SpeakingRecordService(
+            properties(),
+            minioProperties(),
+            todayQuestionService,
+            dailyQuestionRepository,
+            recordRepository,
+            analysisRepository,
+            uploadSessionService,
+            audioStorageService,
+            objectKeyGenerator,
+            progressService,
+            analysisPublisher,
+            analysisLimitService
+    );
+
+    @Test
+    void createRecordCountsInitialAnalysisAndPublishesNonForceEvent() {
+        DailyQuestionEntity dailyQuestion = dailyQuestion();
+        UploadSession session = session(5L);
+        when(uploadSessionService.getRequired("upload-1")).thenReturn(session);
+        when(dailyQuestionRepository.findById(5L)).thenReturn(Optional.of(dailyQuestion));
+        when(recordRepository.existsByUserIdAndDailyQuestionIdAndDeletedAtIsNull(2L, 5L)).thenReturn(false);
+        when(recordRepository.save(any(SpeakingRecordEntity.class))).thenAnswer(invocation -> {
+            SpeakingRecordEntity record = invocation.getArgument(0);
+            ReflectionTestUtils.setField(record, "id", 10L);
+            return record;
+        });
+        when(objectKeyGenerator.permanentKey(2L, 10L, "audio/webm")).thenReturn("speaking/audio/2/2026-05/10.webm");
+        when(analysisRepository.findByRecordId(10L)).thenReturn(Optional.empty());
+
+        SpeakingDtos.RecordResponse response = service.createRecord(2L, new SpeakingDtos.CreateRecordRequest(
+                "upload-1",
+                "speaking/temp/2/upload-1.webm",
+                "I practiced today."
+        ));
+
+        assertThat(response.status()).isEqualTo(SpeakingRecordStatus.ANALYZING);
+        verify(analysisLimitService).acquire(eq(2L), any(LocalDate.class));
+        verify(analysisPublisher).publish(new AnalysisRequestedEvent(10L, 2L, 1, false));
+    }
+
+    @Test
+    void reanalyzeCountsAnalysisAndPublishesForceEventStartingAtFirstAttempt() {
+        SpeakingRecordEntity record = questionRecord(20L, SpeakingRecordStatus.COMPLETED);
+        when(recordRepository.findByIdAndDeletedAtIsNull(20L)).thenReturn(Optional.of(record));
+        when(analysisRepository.findByRecordId(20L)).thenReturn(Optional.empty());
+
+        SpeakingDtos.RecordResponse response = service.reanalyze(2L, 20L);
+
+        assertThat(response.status()).isEqualTo(SpeakingRecordStatus.ANALYZING);
+        verify(analysisLimitService).acquire(eq(2L), any(LocalDate.class));
+        verify(analysisPublisher).publish(new AnalysisRequestedEvent(20L, 2L, 1, true));
+    }
+
+    @Test
+    void createCustomRecordStoresRecordedAudioWithoutAnalysis() {
+        UploadSession session = session(null);
+        when(uploadSessionService.getRequired("upload-custom-1")).thenReturn(session);
+        when(recordRepository.save(any(SpeakingRecordEntity.class))).thenAnswer(invocation -> {
+            SpeakingRecordEntity record = invocation.getArgument(0);
+            ReflectionTestUtils.setField(record, "id", 30L);
+            return record;
+        });
+        when(objectKeyGenerator.permanentKey(2L, 30L, "audio/webm")).thenReturn("speaking/audio/2/2026-05/30.webm");
+        when(analysisRepository.findByRecordId(30L)).thenReturn(Optional.empty());
+
+        SpeakingDtos.RecordResponse response = service.createCustomRecord(2L, new SpeakingDtos.CreateCustomRecordRequest(
+                "upload-custom-1",
+                "speaking/temp/2/upload-1.webm",
+                "내가 직접 쓴 연습 글",
+                "내가 직접 쓴 연습 글"
+        ));
+
+        assertThat(response.dailyQuestionId()).isNull();
+        assertThat(response.question()).isEqualTo("내가 직접 쓴 연습 글");
+        assertThat(response.recordType()).isEqualTo(SpeakingRecordType.CUSTOM_TEXT);
+        assertThat(response.status()).isEqualTo(SpeakingRecordStatus.RECORDED);
+        assertThat(response.analysis()).isNull();
+        verify(analysisLimitService, never()).acquire(anyLong(), any(LocalDate.class));
+        verify(analysisPublisher, never()).publish(any());
+    }
+
+    @Test
+    void createCustomUploadUrlDoesNotCreateDailyQuestion() {
+        when(objectKeyGenerator.tempKey(eq(2L), anyString(), eq("audio/webm"))).thenReturn("speaking/temp/2/upload-fixed.webm");
+        when(audioStorageService.createUploadUrl("speaking/temp/2/upload-fixed.webm")).thenReturn("https://minio.local/upload");
+
+        SpeakingDtos.PresignedUploadResponse response = service.createCustomUploadUrl(2L, new SpeakingDtos.PresignedUploadRequest(
+                "audio/webm",
+                100L,
+                10
+        ));
+
+        assertThat(response.uploadUrl()).isEqualTo("https://minio.local/upload");
+        verify(todayQuestionService, never()).getOrCreateTodayQuestion(any());
+    }
+
+    private UploadSession session(Long dailyQuestionId) {
+        return new UploadSession(
+                "upload-1",
+                2L,
+                dailyQuestionId,
+                "speaking/temp/2/upload-1.webm",
+                "audio/webm",
+                100L,
+                10,
+                Instant.now().plusSeconds(600)
+        );
+    }
+
+    private SpeakingRecordEntity questionRecord(Long id, SpeakingRecordStatus status) {
+        SpeakingRecordEntity record = SpeakingRecordEntity.createPending(
+                2L,
+                dailyQuestion(),
+                "speaking/audio/2/2026-05/20.webm",
+                "I practiced today.",
+                "audio/webm",
+                100L,
+                10
+        );
+        ReflectionTestUtils.setField(record, "id", id);
+        ReflectionTestUtils.setField(record, "status", status);
+        return record;
+    }
+
+    private DailyQuestionEntity dailyQuestion() {
+        QuestionEntity question = BeanUtils.instantiateClass(QuestionEntity.class);
+        ReflectionTestUtils.setField(question, "id", 1L);
+        ReflectionTestUtils.setField(question, "content", "What did you practice today?");
+        DailyQuestionEntity dailyQuestion = DailyQuestionEntity.create(LocalDate.of(2026, 5, 14), SpeakingQuestionType.DAILY, question);
+        ReflectionTestUtils.setField(dailyQuestion, "id", 5L);
+        return dailyQuestion;
+    }
+
+    private SpeakingProperties properties() {
+        return new SpeakingProperties(
+                "Asia/Seoul",
+                10,
+                52_428_800L,
+                300,
+                List.of("audio/webm"),
+                new SpeakingProperties.Rabbit("exchange", "queue", "routing", "dlx", "dlq", "failed"),
+                new SpeakingProperties.Jobs("0 */10 * * * *", "0 0 * * * *", 15, 24),
+                new SpeakingProperties.Gemini(false, "https://generativelanguage.googleapis.com", "", "gemini-2.5-flash-lite", 30)
+        );
+    }
+
+    private MinioProperties minioProperties() {
+        return new MinioProperties("http://minio:9000", "http://minio:9000", "access", "secret", "speaking-audio", 10, 10);
+    }
+}

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/worker/AnalysisWorkerTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/worker/AnalysisWorkerTest.java
@@ -22,7 +22,7 @@ class AnalysisWorkerTest {
 
         worker.handle(event, channel, 99L);
 
-        verify(processingService).process(10L);
+        verify(processingService).process(10L, false);
         verify(channel).basicAck(99L, false);
         verify(analysisPublisher, never()).publish(org.mockito.ArgumentMatchers.any());
     }
@@ -30,11 +30,11 @@ class AnalysisWorkerTest {
     @Test
     void republishesNextAttemptAndAcksOriginalMessageWhenProcessingFailsBelowLimit() throws Exception {
         AnalysisRequestedEvent event = new AnalysisRequestedEvent(10L, 2L, 2);
-        doThrow(new IllegalStateException("timeout")).when(processingService).process(10L);
+        doThrow(new IllegalStateException("timeout")).when(processingService).process(10L, false);
 
         worker.handle(event, channel, 99L);
 
-        verify(analysisPublisher).publish(new AnalysisRequestedEvent(10L, 2L, 3));
+        verify(analysisPublisher).publish(new AnalysisRequestedEvent(10L, 2L, 3, false));
         verify(processingService, never()).fail(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
         verify(channel).basicAck(99L, false);
     }
@@ -42,7 +42,7 @@ class AnalysisWorkerTest {
     @Test
     void marksRecordFailedAndAcksOriginalMessageWhenRetryLimitIsReached() throws Exception {
         AnalysisRequestedEvent event = new AnalysisRequestedEvent(10L, 2L, 3);
-        doThrow(new IllegalStateException("timeout")).when(processingService).process(10L);
+        doThrow(new IllegalStateException("timeout")).when(processingService).process(10L, false);
 
         worker.handle(event, channel, 99L);
 

--- a/UserService/src/main/java/com/lbs/user/chat/controller/ChatMessageController.java
+++ b/UserService/src/main/java/com/lbs/user/chat/controller/ChatMessageController.java
@@ -41,10 +41,10 @@ public class ChatMessageController {
 
         String[] parts = principal.getName().split(":");
         Long senderId = Long.parseLong(parts[0]);
-        String roleStr = parts.length > 1 ? parts[1] : "PARENT";
-        SenderType senderType = "ACADEMY".equalsIgnoreCase(roleStr) ? SenderType.ACADEMY : SenderType.PARENT;
+        String roleStr = parts.length > 1 ? parts[1] : "USER";
+        Role role = normalizeRole(roleStr);
+        SenderType senderType = toSenderType(role);
 
-        Role role = Role.valueOf(roleStr.toUpperCase());
         chatRoomService.getRoomForUser(roomId, senderId, role);
 
         ChatMessage saved = chatMessageService.saveMessage(roomId, senderId, senderType, request);
@@ -52,5 +52,22 @@ public class ChatMessageController {
 
         messagingTemplate.convertAndSend("/topic/chat.rooms." + roomId, response);
         log.info("Message sent to room {}: senderId={}, type={}", roomId, senderId, request.getMessageType());
+    }
+
+    private Role normalizeRole(String role) {
+        if ("USER".equalsIgnoreCase(role) || "ROLE_USER".equalsIgnoreCase(role)) {
+            return Role.USER;
+        }
+        if ("ADMIN".equalsIgnoreCase(role) || "ROLE_ADMIN".equalsIgnoreCase(role)) {
+            return Role.ADMIN;
+        }
+        return Role.USER;
+    }
+
+    private SenderType toSenderType(Role role) {
+        if (role == Role.ADMIN) {
+            return SenderType.ADMIN;
+        }
+        return SenderType.USER;
     }
 }

--- a/UserService/src/main/java/com/lbs/user/chat/controller/ChatRoomController.java
+++ b/UserService/src/main/java/com/lbs/user/chat/controller/ChatRoomController.java
@@ -51,10 +51,10 @@ public class ChatRoomController {
     @GetMapping("/rooms")
     public ResponseEntity<ApiResponse<ChatRoomPageResponseDto>> getMyRooms(
             @RequestParam Long userId,
-            @RequestParam(defaultValue = "PARENT") String role,
+            @RequestParam(defaultValue = "USER") String role,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        Role userRole = Role.valueOf(role.toUpperCase());
+        Role userRole = normalizeRole(role);
         Page<ChatRoom> rooms = chatRoomService.getMyRooms(userId, userRole, PageRequest.of(page, size));
         List<ChatRoomSummaryResponseDto> content = rooms.getContent().stream()
                 .map(r -> chatRoomMapper.toSummaryDto(r, userId, userRole))
@@ -73,12 +73,12 @@ public class ChatRoomController {
     public ResponseEntity<ApiResponse<ChatMessagePageResponseDto>> getMessages(
             @PathVariable("room_id") Long roomId,
             @RequestParam Long userId,
-            @RequestParam(defaultValue = "PARENT") String role,
+            @RequestParam(defaultValue = "USER") String role,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "30") int size) {
-        Role userRole = Role.valueOf(role.toUpperCase());
+        Role userRole = normalizeRole(role);
         chatRoomService.getRoomForUser(roomId, userId, userRole);
-        SenderType senderType = userRole == Role.PARENT ? SenderType.PARENT : SenderType.ACADEMY;
+        SenderType senderType = userRole == Role.ADMIN ? SenderType.ADMIN : SenderType.USER;
         ChatMessagePageResponseDto response = chatMessageService.getMessages(roomId, cursor, size, userId, senderType);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(HttpStatus.OK, response));
@@ -92,5 +92,11 @@ public class ChatRoomController {
                 request.getFileType(), request.getRoomId(), userId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(HttpStatus.OK, "업로드 URL 발급 완료", response));
+    }
+    private Role normalizeRole(String role) {
+        if ("ADMIN".equalsIgnoreCase(role) || "ROLE_ADMIN".equalsIgnoreCase(role)) {
+            return Role.ADMIN;
+        }
+        return Role.USER;
     }
 }

--- a/UserService/src/main/java/com/lbs/user/chat/domain/SenderType.java
+++ b/UserService/src/main/java/com/lbs/user/chat/domain/SenderType.java
@@ -1,3 +1,3 @@
 package com.lbs.user.chat.domain;
 
-public enum SenderType { PARENT, ACADEMY }
+public enum SenderType { USER, ADMIN }

--- a/UserService/src/main/java/com/lbs/user/chat/infrastructure/repository/jpa/JpaChatRoomRepository.java
+++ b/UserService/src/main/java/com/lbs/user/chat/infrastructure/repository/jpa/JpaChatRoomRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface JpaChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
     Optional<ChatRoomEntity> findByAcademyIdAndParentId(Long academyId, Long parentId);
+    Page<ChatRoomEntity> findAllByOrderByLastMessageAtDesc(Pageable pageable);
+    Page<ChatRoomEntity> findAllByAcademyIdOrParentIdOrderByLastMessageAtDesc(Long academyId, Long parentId, Pageable pageable);
     Page<ChatRoomEntity> findAllByParentIdOrderByLastMessageAtDesc(Long parentId, Pageable pageable);
     Page<ChatRoomEntity> findAllByAcademyIdOrderByLastMessageAtDesc(Long academyId, Pageable pageable);
 }

--- a/UserService/src/main/java/com/lbs/user/chat/infrastructure/repository/jpa/JpaChatRoomRepositoryAdapter.java
+++ b/UserService/src/main/java/com/lbs/user/chat/infrastructure/repository/jpa/JpaChatRoomRepositoryAdapter.java
@@ -48,11 +48,11 @@ public class JpaChatRoomRepositoryAdapter implements ChatRoomRepository {
     @Override
     @Transactional(readOnly = true)
     public Page<ChatRoom> findAllByUser(Long userId, Role role, Pageable pageable) {
-        if (role == Role.PARENT) {
-            return jpaChatRoomRepository.findAllByParentIdOrderByLastMessageAtDesc(userId, pageable)
+        if (role == Role.ADMIN) {
+            return jpaChatRoomRepository.findAllByOrderByLastMessageAtDesc(pageable)
                     .map(chatRoomMapper::entityToDomain);
         }
-        return jpaChatRoomRepository.findAllByAcademyIdOrderByLastMessageAtDesc(userId, pageable)
+        return jpaChatRoomRepository.findAllByAcademyIdOrParentIdOrderByLastMessageAtDesc(userId, userId, pageable)
                 .map(chatRoomMapper::entityToDomain);
     }
 

--- a/UserService/src/main/java/com/lbs/user/chat/mapper/ChatRoomMapper.java
+++ b/UserService/src/main/java/com/lbs/user/chat/mapper/ChatRoomMapper.java
@@ -33,8 +33,10 @@ public interface ChatRoomMapper {
     ChatRoomResponseDto domainToResponseDto(ChatRoom domain);
 
     default ChatRoomSummaryResponseDto toSummaryDto(ChatRoom chatRoom, Long requestUserId, Role role) {
-        Long counterpartId = role == Role.PARENT ? chatRoom.getAcademyId() : chatRoom.getParentId();
-        SenderType counterpartType = role == Role.PARENT ? SenderType.ACADEMY : SenderType.PARENT;
+        Long counterpartId = chatRoom.getParentId().equals(requestUserId)
+                ? chatRoom.getAcademyId()
+                : chatRoom.getParentId();
+        SenderType counterpartType = role == Role.ADMIN ? SenderType.ADMIN : SenderType.USER;
         return ChatRoomSummaryResponseDto.builder()
                 .roomId(chatRoom.getId())
                 .counterpartId(counterpartId)

--- a/UserService/src/main/java/com/lbs/user/chat/service/ChatRoomServiceImpl.java
+++ b/UserService/src/main/java/com/lbs/user/chat/service/ChatRoomServiceImpl.java
@@ -42,9 +42,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     public ChatRoom getRoomForUser(Long roomId, Long userId, Role role) {
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new ChatRoomNotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-        boolean isParticipant = role == Role.PARENT
-                ? room.getParentId().equals(userId)
-                : room.getAcademyId().equals(userId);
+        boolean isParticipant = switch (role) {
+            case USER -> room.getParentId().equals(userId) || room.getAcademyId().equals(userId);
+            case ADMIN -> true;
+        };
         if (!isParticipant) {
             throw new ChatRoomForbiddenException(ErrorCode.CHAT_ROOM_FORBIDDEN);
         }

--- a/UserService/src/main/java/com/lbs/user/user/domain/Role.java
+++ b/UserService/src/main/java/com/lbs/user/user/domain/Role.java
@@ -1,5 +1,5 @@
 package com.lbs.user.user.domain;
 
 public enum Role {
-    PARENT, ACADEMY, ADMIN
+    USER, ADMIN
 }

--- a/UserService/src/main/java/com/lbs/user/user/jwt/JWTAuthenticationFilter.java
+++ b/UserService/src/main/java/com/lbs/user/user/jwt/JWTAuthenticationFilter.java
@@ -1,7 +1,8 @@
 package com.lbs.user.user.jwt;
 
 import io.jsonwebtoken.JwtException;
-import jakarta.servlet.*;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +14,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-/**
- * 요청 시 jwt 토큰 검사 필터
- * 작성자  : lbs
- * 날짜    : 2025-05-11
- **/
-
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -26,26 +21,21 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
         String token = jwtTokenProvider.resolveToken(request);
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            //validateToken 에러 시 jwtException filter 실행 됨
-
-            //나중에 redis에 있는  블랙 리스트도 추가해주자!
-//            if (redisUtil.getData(token) != null) {
-//                jwtExceptionHandler(response, ErrorCode.BLACK_LIST_TOKEN);
-//                return;
-//            }
-            //로그인 같은 jwt token이 없는경우에는 어떻게하지?
-            // login 페이지로 이동시켜야할 꺼 같다. 나중에 시켜보자.
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (JwtException e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            return;
         }
+
         filterChain.doFilter(request, response);
-
-
     }
-
 }
-

--- a/UserService/src/main/java/com/lbs/user/user/security/CustomOAuth2AuthenticationSuccessHandler.java
+++ b/UserService/src/main/java/com/lbs/user/user/security/CustomOAuth2AuthenticationSuccessHandler.java
@@ -49,7 +49,7 @@ public class CustomOAuth2AuthenticationSuccessHandler implements AuthenticationS
         var authorities = user.getRoles().stream()
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
-        String primaryRole = user.getRoles().isEmpty() ? "PARENT" : user.getRoles().get(0);
+        String primaryRole = user.getRoles().isEmpty() ? "ROLE_USER" : user.getRoles().get(0);
 
         String token = jwtTokenProvider.generateAccessToken(
                 user.getId(), user.getEmail(), user.getName(), primaryRole, authorities);

--- a/UserService/src/main/resources/static/chat/index.html
+++ b/UserService/src/main/resources/static/chat/index.html
@@ -55,8 +55,8 @@
     <input id="user-id" value="1" type="number" />
     <label>Role</label>
     <select id="user-role">
-        <option value="PARENT">PARENT</option>
-        <option value="ACADEMY">ACADEMY</option>
+        <option value="USER">USER</option>
+        <option value="ADMIN">ADMIN</option>
     </select>
     <div style="margin-bottom:8px;">
         <button class="btn-primary" onclick="createRoom()">채팅방 생성/조회</button>
@@ -156,8 +156,8 @@ async function createRoom() {
     const userId = document.getElementById('user-id').value;
     const role = document.getElementById('user-role').value;
     const roomId = document.getElementById('room-id').value;
-    const academyId = role === 'ACADEMY' ? userId : roomId;
-    const parentId  = role === 'PARENT'  ? userId : roomId;
+    const academyId = roomId;
+    const parentId  = userId;
     const res = await fetch(apiBase() + '/api/user-service/chat/rooms/create', {
         method: 'POST', headers: authHeader(),
         body: JSON.stringify({ academyId: parseInt(academyId), parentId: parseInt(parentId) })

--- a/scripts/k6/deck-search.js
+++ b/scripts/k6/deck-search.js
@@ -15,7 +15,6 @@ export const options = {
   },
   thresholds: {
     http_req_duration: ['p(95)<500'],
-    http_req_failed: ['rate<0.01'],
   },
 };
 
@@ -29,11 +28,16 @@ export default function () {
     `${BASE}/deck/search?category=${encodeURIComponent(cat)}&sort=createdDate,desc&page=${page}&size=20`
   );
   check(res, { 'status 200': (r) => r.status === 200 });
+  sleep(1);
 }
 
 export function handleSummary(data) {
+  // 측정된 TPS (초당 요청 수) 가져오기
+  const tps = data.metrics.http_reqs.values.rate; 
+  
   return {
     'docs/perf/results/summary.json': JSON.stringify(data, null, 2),
-    stdout: JSON.stringify(data.metrics['http_req_duration'], null, 2),
+    // 응답 시간과 함께 TPS 수치도 콘솔(stdout)에 같이 출력하도록 수정
+    stdout: `[응답 시간]\n${JSON.stringify(data.metrics['http_req_duration'], null, 2)}\n\n[측정된 TPS]\n${tps.toFixed(2)} 요청/초\n`,
   };
 }


### PR DESCRIPTION
## Summary

- `SpeakingQuestionType` (DAILY/INTERVIEW) 추가 — 일상 질문과 면접 질문을 별도 풀로 관리
- `SpeakingRecordType` (QUESTION_ANALYSIS/CUSTOM_TEXT) 추가 — 자유 텍스트 연습 지원
- `ReanalysisLimitService` → `AnalysisLimitService` 통합 — 최초 분석 + 재분석 모두 일일 5회 제한 적용
- MIME type 정규화 (`audio/webm;codecs=opus` → `audio/webm`)
- 신규 API: `GET /interview/today`, `POST /custom/uploads/presigned-url`, `POST /custom/records`
- Flyway migration V2~V5 (질문 타입 컬럼, Interview 시드 데이터, analysis feedback, custom record)

## Changed Services

- `SpeakingService` — 신규 기능 전체
- `UserService` — chat 도메인 개선 (ChatRoom, JWT filter)

## Test plan

- [ ] SpeakingService 빌드 확인 (Jenkins)
- [ ] UserService 빌드 확인 (Jenkins)
- [ ] `GET /api/speaking-service/speaking/today` 헬스체크
- [ ] `GET /api/speaking-service/speaking/interview/today` 응답 확인
- [ ] Flyway migration V2~V5 정상 적용 확인