### PR TITLE
fix: allow evil55 origin for gateway cors

### DIFF
--- a/GatewayService/src/main/resources/application.yml
+++ b/GatewayService/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
           '[/**]':
             allowedOrigins:
               - "http://localhost:3000"
+              - "http://evil55.cloud"
+              - "https://evil55.cloud"
             allowedMethods:
               - GET
               - POST


### PR DESCRIPTION
## Summary
- Allow `http://evil55.cloud` and `https://evil55.cloud` in Gateway CORS origins.
- Fix preflight 403 for authenticated speaking POST requests from the deployed frontend origin.

## Test
- `cd GatewayService && ./gradlew.bat test`
- Local preflight check: `Origin: https://evil55.cloud` -> `200`, `Access-Control-Allow-Origin=https://evil55.cloud`