### PR TITLE
fix: set minio region for speaking presigned urls

### DIFF
--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AudioStorageService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/AudioStorageService.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class AudioStorageService {
 
+    private static final String DEFAULT_REGION = "us-east-1";
+
     private final MinioClient minioClient;
     private final MinioClient presignedMinioClient;
     private final MinioProperties properties;
@@ -41,6 +43,7 @@ public class AudioStorageService {
             return presignedMinioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
                     .method(Method.PUT)
                     .bucket(properties.bucket())
+                    .region(DEFAULT_REGION)
                     .object(objectKey)
                     .expiry(properties.presignedPutExpiryMinutes(), TimeUnit.MINUTES)
                     .build());
@@ -54,6 +57,7 @@ public class AudioStorageService {
             return presignedMinioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
                     .method(Method.GET)
                     .bucket(properties.bucket())
+                    .region(DEFAULT_REGION)
                     .object(objectKey)
                     .expiry(properties.presignedGetExpiryMinutes(), TimeUnit.MINUTES)
                     .build());


### PR DESCRIPTION
## Summary
- Set the MinIO/S3 region explicitly when creating speaking presigned upload/download URLs.
- Avoid bucket region lookup through the public endpoint, which can fail behind nginx and surface as `STORAGE_OPERATION_FAILED`.

## Test
- `cd SpeakingService && ./gradlew.bat test`