### PR TITLE
fix: publish speaking analysis after transaction commit

### DIFF
--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisPublisher.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/worker/AnalysisPublisher.java
@@ -6,6 +6,8 @@ import com.lbs.speaking.config.SpeakingProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -15,6 +17,19 @@ public class AnalysisPublisher {
     private final SpeakingProperties properties;
 
     public void publish(AnalysisRequestedEvent event) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    send(event);
+                }
+            });
+            return;
+        }
+        send(event);
+    }
+
+    private void send(AnalysisRequestedEvent event) {
         try {
             rabbitTemplate.convertAndSend(
                     properties.rabbitmq().exchange(),

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/worker/AnalysisPublisherTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/worker/AnalysisPublisherTest.java
@@ -1,0 +1,59 @@
+package com.lbs.speaking.speaking.worker;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.lbs.speaking.config.SpeakingProperties;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+class AnalysisPublisherTest {
+
+    private final RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+    private final SpeakingProperties properties = mock(SpeakingProperties.class);
+    private final AnalysisPublisher publisher = new AnalysisPublisher(rabbitTemplate, properties);
+
+    @AfterEach
+    void tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void publishSendsImmediatelyWhenTransactionSynchronizationIsNotActive() {
+        SpeakingProperties.Rabbit rabbit = rabbitProperties();
+        when(properties.rabbitmq()).thenReturn(rabbit);
+        AnalysisRequestedEvent event = new AnalysisRequestedEvent(10L, 2L, 1, false);
+
+        publisher.publish(event);
+
+        verify(rabbitTemplate).convertAndSend("exchange", "routing", event);
+    }
+
+    @Test
+    void publishSendsAfterCommitWhenTransactionSynchronizationIsActive() {
+        SpeakingProperties.Rabbit rabbit = rabbitProperties();
+        when(properties.rabbitmq()).thenReturn(rabbit);
+        AnalysisRequestedEvent event = new AnalysisRequestedEvent(10L, 2L, 1, false);
+        TransactionSynchronizationManager.initSynchronization();
+
+        publisher.publish(event);
+
+        verify(rabbitTemplate, never()).convertAndSend("exchange", "routing", event);
+        List<TransactionSynchronization> synchronizations = TransactionSynchronizationManager.getSynchronizations();
+        synchronizations.forEach(TransactionSynchronization::afterCommit);
+
+        verify(rabbitTemplate).convertAndSend("exchange", "routing", event);
+    }
+
+    private SpeakingProperties.Rabbit rabbitProperties() {
+        return new SpeakingProperties.Rabbit("exchange", "queue", "routing", "dlx", "dlq", "failed");
+    }
+}


### PR DESCRIPTION
## Summary
- Publish speaking analysis RabbitMQ events after the surrounding DB transaction commits
- Keep immediate publish behavior when no transaction synchronization is active
- Add tests for immediate and after-commit publishing

## Verification
- `./gradlew.bat test`
- `./gradlew.bat clean bootJar -x test`
- Deployed SpeakingService and verified a question analysis record reaches `COMPLETED` with analysis data