### PR TITLE
feat: support sentence-level speaking highlights

### DIFF
--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiAnalysisParser.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiAnalysisParser.java
@@ -41,7 +41,10 @@ public class GeminiAnalysisParser {
                                     block.kind(),
                                     block.text(),
                                     block.color(),
-                                    block.issueIndex()
+                                    block.issueIndex(),
+                                    block.sentenceIndex(),
+                                    block.role(),
+                                    block.issueIndexes()
                             ))
                             .toList(),
                     toFeedback(payload.feedback())
@@ -158,7 +161,10 @@ public class GeminiAnalysisParser {
             String kind,
             String text,
             String color,
-            Integer issueIndex
+            Integer issueIndex,
+            Integer sentenceIndex,
+            String role,
+            List<Integer> issueIndexes
     ) {
     }
 }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiPromptBuilder.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/GeminiPromptBuilder.java
@@ -55,12 +55,19 @@ public class GeminiPromptBuilder {
             - explanation must be Korean.
 
             Rendering rules:
-            - renderBlocks are used by the frontend for red to blue correction rendering.
-            - Use red blocks for original phrases that should be improved.
-            - Use blue blocks for improved phrases.
+            - renderBlocks are used by the frontend for sentence-by-sentence red to blue correction rendering.
+            - Split the learner answer into sentence-sized units. Use sentenceIndex starting at 0.
+            - For each sentence that has a concrete improvement, output two visual rows:
+              1. role="original": the learner's original sentence, split into normal context blocks and red issue blocks.
+              2. role="improved": the improved sentence, split into normal context blocks and blue improvement blocks.
+            - Keep sentenceIndex the same for the original row and its improved row.
+            - Use red blocks only for exact original phrases that should be improved.
+            - Use blue blocks for the replacement or newly improved phrase in the improved sentence.
             - Use normal blocks for unchanged context.
-            - If an issue is not highlightable, do not create a red block for it.
-            - issueIndex must point to the related issue index when kind is original or improved.
+            - If an issue is not highlightable, do not create a red block for it, but still include the issue in issues.
+            - issueIndex must point to the main related issue index when kind is original or improved.
+            - issueIndexes must include every related issue index for that block. Use an empty array for normal context.
+            - If a sentence has no concrete issue, you may omit it from renderBlocks.
 
             Output rules:
             - Return only valid JSON.
@@ -100,7 +107,10 @@ public class GeminiPromptBuilder {
                   "kind": "original | improved | normal",
                   "text": "string",
                   "color": "red | blue | none",
-                  "issueIndex": 0
+                  "issueIndex": 0,
+                  "sentenceIndex": 0,
+                  "role": "original | improved",
+                  "issueIndexes": [0]
                 }
               ]
             }

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/LlmAnalysisPort.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/LlmAnalysisPort.java
@@ -29,8 +29,16 @@ public interface LlmAnalysisPort {
             String kind,
             String text,
             String color,
-            Integer issueIndex
+            Integer issueIndex,
+            Integer sentenceIndex,
+            String role,
+            List<Integer> issueIndexes
     ) {
+        public RenderBlock {
+            if (issueIndexes == null) {
+                issueIndexes = List.of();
+            }
+        }
     }
 
     record Feedback(

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/MockGeminiAnalysisAdapter.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/MockGeminiAnalysisAdapter.java
@@ -17,7 +17,7 @@ public class MockGeminiAnalysisAdapter implements LlmAnalysisPort {
         return new LlmAnalysisResult(
                 improved,
                 List.of(),
-                List.of(new RenderBlock("improved", improved, "blue", null)),
+                List.of(new RenderBlock("improved", improved, "blue", null, 0, "improved", List.of())),
                 new Feedback(
                         80,
                         "답변을 잘 완성했어요. 개선 답변을 보며 한 번 더 말해보세요.",

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisProcessingServiceTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/AnalysisProcessingServiceTest.java
@@ -54,7 +54,7 @@ class AnalysisProcessingServiceTest {
     void forceProcessReplacesExistingAnalysisEvenWhenRecordIsCompleted() {
         SpeakingRecordEntity record = record(10L, SpeakingRecordStatus.COMPLETED);
         AnalysisEntity existingAnalysis = AnalysisEntity.create(record, "old", "[]", "[]", "{}");
-        LlmAnalysisPort.RenderBlock block = new LlmAnalysisPort.RenderBlock("improved", "I went", "blue", 0);
+        LlmAnalysisPort.RenderBlock block = new LlmAnalysisPort.RenderBlock("improved", "I went", "blue", 0, 0, "improved", List.of(0));
         LlmAnalysisPort.LlmAnalysisResult result = new LlmAnalysisPort.LlmAnalysisResult(
                 "I went home again.",
                 List.of(),
@@ -88,7 +88,7 @@ class AnalysisProcessingServiceTest {
                 "Past tense is needed.",
                 true
         );
-        LlmAnalysisPort.RenderBlock block = new LlmAnalysisPort.RenderBlock("improved", "I went", "blue", 0);
+        LlmAnalysisPort.RenderBlock block = new LlmAnalysisPort.RenderBlock("improved", "I went", "blue", 0, 0, "improved", List.of(0));
         LlmAnalysisPort.LlmAnalysisResult result = new LlmAnalysisPort.LlmAnalysisResult(
                 "I went home.",
                 List.of(issue),

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisParserTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiAnalysisParserTest.java
@@ -37,8 +37,24 @@ class GeminiAnalysisParserTest {
                     }
                   ],
                   "renderBlocks": [
-                    {"kind": "original", "text": "go school", "color": "red", "issueIndex": 0},
-                    {"kind": "improved", "text": "go to school", "color": "blue", "issueIndex": 0}
+                    {
+                      "kind": "original",
+                      "text": "go school",
+                      "color": "red",
+                      "issueIndex": 0,
+                      "sentenceIndex": 0,
+                      "role": "original",
+                      "issueIndexes": [0]
+                    },
+                    {
+                      "kind": "improved",
+                      "text": "go to school",
+                      "color": "blue",
+                      "issueIndex": 0,
+                      "sentenceIndex": 0,
+                      "role": "improved",
+                      "issueIndexes": [0]
+                    }
                   ]
                 }
                 Thanks.
@@ -50,6 +66,9 @@ class GeminiAnalysisParserTest {
         assertThat(result.issues()).hasSize(1);
         assertThat(result.issues().get(0).suggestion()).isEqualTo("go to school");
         assertThat(result.renderBlocks()).hasSize(2);
+        assertThat(result.renderBlocks().get(0).sentenceIndex()).isEqualTo(0);
+        assertThat(result.renderBlocks().get(0).role()).isEqualTo("original");
+        assertThat(result.renderBlocks().get(0).issueIndexes()).containsExactly(0);
         assertThat(result.feedback().overallScore()).isEqualTo(86);
         assertThat(result.feedback().metrics().get(0).label()).isEqualTo("유창성");
     }

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiPromptBuilderTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/GeminiPromptBuilderTest.java
@@ -24,6 +24,10 @@ class GeminiPromptBuilderTest {
         assertThat(prompt).contains("relevance, label:");
         assertThat(prompt).contains("\"issues\"");
         assertThat(prompt).contains("\"renderBlocks\"");
+        assertThat(prompt).contains("\"sentenceIndex\"");
+        assertThat(prompt).contains("\"role\"");
+        assertThat(prompt).contains("\"issueIndexes\"");
+        assertThat(prompt).contains("sentence-by-sentence");
         assertThat(prompt).contains("red");
         assertThat(prompt).contains("blue");
         assertThat(prompt).contains(GeminiPromptBuilder.VARIABLE_INPUT_MARKER);


### PR DESCRIPTION
## Summary
- Extend Gemini speaking analysis render blocks with sentence-level metadata
- Update the prompt contract so original and improved rows can be rendered per sentence
- Keep existing render block fields for backward compatibility

## Verification
- `./gradlew.bat test`
- `pnpm type-check`
- `pnpm build`
- `pnpm test:e2e -- speaking.spec.ts`

Frontend rendering changes are pushed to `byeongsuLEE/learn-front#5` branch `codex/speaking-practice-ui`.