### PR TITLE
feat: allow rerecording speaking answers

### DIFF
--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordEntity.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/entity/SpeakingRecordEntity.java
@@ -113,6 +113,17 @@ public class SpeakingRecordEntity extends BaseEntity {
         this.failureReason = null;
     }
 
+    public void replacePendingAnalysis(String objectKey, String originalText, String mimeType, long sizeBytes,
+                                       int durationSec) {
+        this.objectKey = objectKey;
+        this.originalText = originalText;
+        this.mimeType = mimeType;
+        this.sizeBytes = sizeBytes;
+        this.durationSec = durationSec;
+        this.status = SpeakingRecordStatus.PENDING_ANALYSIS;
+        this.failureReason = null;
+    }
+
     public void markCompleted() {
         this.status = SpeakingRecordStatus.COMPLETED;
         this.failureReason = null;

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/SpeakingRecordJpaRepository.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/infrastructure/repository/SpeakingRecordJpaRepository.java
@@ -12,6 +12,8 @@ public interface SpeakingRecordJpaRepository extends JpaRepository<SpeakingRecor
 
     boolean existsByUserIdAndDailyQuestionIdAndDeletedAtIsNull(Long userId, Long dailyQuestionId);
 
+    Optional<SpeakingRecordEntity> findByUserIdAndDailyQuestionIdAndDeletedAtIsNull(Long userId, Long dailyQuestionId);
+
     Optional<SpeakingRecordEntity> findByIdAndDeletedAtIsNull(Long id);
 
     List<SpeakingRecordEntity> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId);

--- a/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/SpeakingRecordService.java
+++ b/SpeakingService/src/main/java/com/lbs/speaking/speaking/service/SpeakingRecordService.java
@@ -111,13 +111,13 @@ public class SpeakingRecordService {
 
         DailyQuestionEntity dailyQuestion = dailyQuestionRepository.findById(session.dailyQuestionId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TODAY_QUESTION_NOT_FOUND));
-        if (recordRepository.existsByUserIdAndDailyQuestionIdAndDeletedAtIsNull(userId, dailyQuestion.getId())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_DAILY_ANSWER);
-        }
+        var existingRecord = recordRepository.findByUserIdAndDailyQuestionIdAndDeletedAtIsNull(userId, dailyQuestion.getId());
         analysisLimitService.acquire(userId, LocalDate.now(properties.zoneId()));
 
         audioStorageService.assertExists(session.objectKey());
-        SpeakingRecordEntity record = savePendingRecord(userId, dailyQuestion, request.transcript(), session);
+        SpeakingRecordEntity record = existingRecord
+                .map(existing -> replaceExistingRecordForAnalysis(existing, request.transcript(), session))
+                .orElseGet(() -> savePendingRecord(userId, dailyQuestion, request.transcript(), session));
         progressService.setProgress(record.getId(), 55);
 
         String permanentObjectKey = objectKeyGenerator.permanentKey(userId, record.getId(), session.mimeType());
@@ -127,7 +127,7 @@ public class SpeakingRecordService {
         record.markAnalyzing(permanentObjectKey);
         progressService.setProgress(record.getId(), 70);
         uploadSessionService.delete(session.uploadId());
-        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, 1, false));
+        analysisPublisher.publish(new AnalysisRequestedEvent(record.getId(), userId, 1, existingRecord.isPresent()));
         return toRecordResponse(record);
     }
 
@@ -171,6 +171,18 @@ public class SpeakingRecordService {
         } catch (DataIntegrityViolationException exception) {
             throw new BusinessException(ErrorCode.DUPLICATE_DAILY_ANSWER, exception);
         }
+    }
+
+    private SpeakingRecordEntity replaceExistingRecordForAnalysis(SpeakingRecordEntity record, String transcript,
+                                                                  UploadSession session) {
+        record.replacePendingAnalysis(
+                session.objectKey(),
+                transcript,
+                session.mimeType(),
+                session.sizeBytes(),
+                session.durationSec()
+        );
+        return record;
     }
 
     @Transactional(readOnly = true)

--- a/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceTest.java
+++ b/SpeakingService/src/test/java/com/lbs/speaking/speaking/service/SpeakingRecordServiceTest.java
@@ -65,7 +65,7 @@ class SpeakingRecordServiceTest {
         UploadSession session = session(5L);
         when(uploadSessionService.getRequired("upload-1")).thenReturn(session);
         when(dailyQuestionRepository.findById(5L)).thenReturn(Optional.of(dailyQuestion));
-        when(recordRepository.existsByUserIdAndDailyQuestionIdAndDeletedAtIsNull(2L, 5L)).thenReturn(false);
+        when(recordRepository.findByUserIdAndDailyQuestionIdAndDeletedAtIsNull(2L, 5L)).thenReturn(Optional.empty());
         when(recordRepository.save(any(SpeakingRecordEntity.class))).thenAnswer(invocation -> {
             SpeakingRecordEntity record = invocation.getArgument(0);
             ReflectionTestUtils.setField(record, "id", 10L);
@@ -83,6 +83,31 @@ class SpeakingRecordServiceTest {
         assertThat(response.status()).isEqualTo(SpeakingRecordStatus.ANALYZING);
         verify(analysisLimitService).acquire(eq(2L), any(LocalDate.class));
         verify(analysisPublisher).publish(new AnalysisRequestedEvent(10L, 2L, 1, false));
+    }
+
+    @Test
+    void createRecordReplacesExistingDailyRecordAndPublishesForceEvent() {
+        DailyQuestionEntity dailyQuestion = dailyQuestion();
+        UploadSession session = session(5L);
+        SpeakingRecordEntity existing = questionRecord(20L, SpeakingRecordStatus.COMPLETED);
+        when(uploadSessionService.getRequired("upload-1")).thenReturn(session);
+        when(dailyQuestionRepository.findById(5L)).thenReturn(Optional.of(dailyQuestion));
+        when(recordRepository.findByUserIdAndDailyQuestionIdAndDeletedAtIsNull(2L, 5L)).thenReturn(Optional.of(existing));
+        when(objectKeyGenerator.permanentKey(2L, 20L, "audio/webm")).thenReturn("speaking/audio/2/2026-05/20.webm");
+        when(analysisRepository.findByRecordId(20L)).thenReturn(Optional.empty());
+
+        SpeakingDtos.RecordResponse response = service.createRecord(2L, new SpeakingDtos.CreateRecordRequest(
+                "upload-1",
+                "speaking/temp/2/upload-1.webm",
+                "I recorded a better answer."
+        ));
+
+        assertThat(response.id()).isEqualTo(20L);
+        assertThat(response.originalText()).isEqualTo("I recorded a better answer.");
+        assertThat(response.status()).isEqualTo(SpeakingRecordStatus.ANALYZING);
+        verify(recordRepository, never()).save(any(SpeakingRecordEntity.class));
+        verify(analysisLimitService).acquire(eq(2L), any(LocalDate.class));
+        verify(analysisPublisher).publish(new AnalysisRequestedEvent(20L, 2L, 1, true));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Allow submitting a new recording for an already answered daily/interview speaking question
- Reuse the existing speaking record, replace its audio/transcript metadata, and publish a force analysis event
- Keep the daily question uniqueness constraint while enabling rerecord + reanalysis UX

## Verification
- `./gradlew.bat test`
- `pnpm type-check`
- `pnpm build`
- `pnpm test:e2e -- speaking.spec.ts`